### PR TITLE
Add CLAUDE.md documenting current repository state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,18 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Status
+
+This is a greenfield repository named "Pop". As of the last update to this file, it contains only a README.md and no source code, build tooling, tests, or CI configuration.
+
+## Current State
+
+- No package manager, build system, or language toolchain has been set up yet.
+- There are no build, lint, or test commands to run.
+- There is no established architecture or directory structure.
+
+## Guidance
+
+- When the first code is added, establish the project's language, tooling, and structure based on the user's requirements rather than assumptions.
+- Update this file once build/test commands and an architecture exist, so future sessions have accurate instructions.


### PR DESCRIPTION
## Summary
- Adds a `CLAUDE.md` file to guide Claude Code sessions in this repository.
- The repository currently contains only a README, so the file honestly documents the greenfield state (no build/test/lint tooling, no architecture yet) and instructs future sessions to update it once code and tooling exist.

https://claude.ai/code/session_01NpJmp92eXtHXrGTnyThvKk

---
_Generated by [Claude Code](https://claude.ai/code/session_01NpJmp92eXtHXrGTnyThvKk)_