### PR TITLE
Add CLAUDE.md with repository guidance for AI assistants

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,32 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Repository Overview
+
+**Pop** is a newly initialized repository. As of this writing it contains no source code, build system, or tooling — only this file and a `README.md` with the project title. There is no established language, framework, or architecture yet.
+
+## Current Structure
+
+```
+Pop/
+├── README.md   # Project title only
+└── CLAUDE.md   # This file
+```
+
+## Development Workflow
+
+- The default branch is `main`.
+- Feature work happens on branches (e.g. `claude/<topic>`) and is merged via pull requests.
+- There are no build, test, or lint commands yet — none are configured.
+
+## Guidance for AI Assistants
+
+Because the project is a blank slate:
+
+1. **Don't assume a stack.** No language, package manager, or framework has been chosen. Ask the user (or infer from their request) before scaffolding anything.
+2. **Establish conventions as code is added.** When the first real code lands, update this file with:
+   - Build, test, and lint commands
+   - Directory layout and architecture notes
+   - Any project-specific conventions (naming, formatting, commit style)
+3. **Keep this file current.** Update it whenever tooling, structure, or workflows change so it stays an accurate map of the codebase.


### PR DESCRIPTION
## Summary

Adds a `CLAUDE.md` file to guide Claude Code (and other AI assistants) when working in this repository.

Since the repository is newly initialized and contains only a `README.md` with the project title, the file honestly documents that state rather than inventing structure:

- **Repository overview** — notes that no language, framework, or tooling has been chosen yet
- **Current structure** — the two files that exist today
- **Development workflow** — default branch (`main`), branch-and-PR flow, and that no build/test/lint commands are configured
- **Guidance for AI assistants** — don't assume a stack, establish and document conventions as the first real code lands, and keep this file up to date as the project grows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q1LCr7EAj9i8Jin5RW1jcM

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1LCr7EAj9i8Jin5RW1jcM)_