### PR TITLE
Workout v2 (phases 1+2): exercise library, structured sessions, PR detection, program templates

### DIFF
--- a/xcamp-gym-sql/dashboard/captains.php
+++ b/xcamp-gym-sql/dashboard/captains.php
@@ -79,6 +79,10 @@ if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
             $targetMember = (int)$pdo->query("SELECT member_id FROM progress_tracking WHERE progress_id = " . (int)$_POST['progress_id'])->fetchColumn();
         } elseif ($act === 'set_injury_status') {
             $targetMember = (int)$pdo->query("SELECT member_id FROM injury_history WHERE injury_id = " . (int)$_POST['injury_id'])->fetchColumn();
+        } elseif ($act === 'add_session_exercise') {
+            $targetMember = (int)$pdo->query("SELECT wp.member_id FROM workout_sessions ws JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id WHERE ws.session_id = " . (int)$_POST['session_id'])->fetchColumn();
+        } elseif ($act === 'delete_session_exercise') {
+            $targetMember = (int)$pdo->query("SELECT wp.member_id FROM session_exercises se JOIN workout_sessions ws ON ws.session_id = se.session_id JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id WHERE se.session_exercise_id = " . (int)$_POST['session_exercise_id'])->fetchColumn();
         }
         if (!member_allowed($pdo, $me, $targetMember)) throw new RuntimeException('غير مسموح بتعديل هذا العضو.');
 
@@ -195,6 +199,73 @@ if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
         } elseif ($act === 'set_injury_status') {
             $pdo->prepare("UPDATE injury_history SET current_status = ?, doctor_clearance = ? WHERE injury_id = ?")
                 ->execute([$_POST['current_status'], isset($_POST['doctor_clearance']) ? 1 : 0, (int)$_POST['injury_id']]);
+        } elseif ($act === 'add_session_exercise') {
+            $exId = (int)$_POST['exercise_id'];
+            $load = $_POST['load_kg'] !== '' ? (float)$_POST['load_kg'] : null;
+            // أقصى حمل سابق لهذا العضو/التمرين — لاكتشاف الرقم القياسي (PR)
+            $prev = null;
+            if ($load !== null) {
+                $pm = $pdo->prepare("SELECT MAX(se.load_kg) FROM session_exercises se
+                                     JOIN workout_sessions ws ON ws.session_id = se.session_id
+                                     JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                                     WHERE wp.member_id = ? AND se.exercise_id = ?");
+                $pm->execute([$targetMember, $exId]);
+                $prev = $pm->fetchColumn();
+                $prev = ($prev !== null && $prev !== false) ? (float)$prev : null;
+            }
+            $pdo->prepare("INSERT INTO session_exercises (session_id, exercise_id, sort_order, sets, reps, load_kg, rest_sec, rpe, notes)
+                           VALUES (?,?,?,?,?,?,?,?,?)")->execute([
+                (int)$_POST['session_id'], $exId, max(1, (int)($_POST['sort_order'] ?: 1)),
+                $_POST['sets'] !== '' ? (int)$_POST['sets'] : null,
+                trim($_POST['reps'] ?? '') ?: null, $load,
+                $_POST['rest_sec'] !== '' ? (int)$_POST['rest_sec'] : null,
+                $_POST['rpe'] !== '' ? (int)$_POST['rpe'] : null,
+                trim($_POST['notes'] ?? '') ?: null,
+            ]);
+            if ($load !== null && $prev !== null && $load > $prev) {
+                // 🏆 رقم قياسي جديد → إنجاز تلقائي
+                $exName = $pdo->query("SELECT name FROM exercises WHERE exercise_id = $exId")->fetchColumn();
+                $pdo->prepare("INSERT INTO milestones (member_id, milestone_date, milestone_type, description, reward_status)
+                               VALUES (?, CURDATE(), 'strength_gain', ?, 'badge')")
+                    ->execute([$targetMember, "🏆 رقم قياسي جديد في {$exName}: {$load} كجم (السابق: {$prev})"]);
+            }
+        } elseif ($act === 'delete_session_exercise') {
+            $pdo->prepare("DELETE FROM session_exercises WHERE session_exercise_id = ?")->execute([(int)$_POST['session_exercise_id']]);
+        } elseif ($act === 'assign_template') {
+            $tpl = $pdo->prepare("SELECT * FROM program_templates WHERE template_id = ? AND active = 1");
+            $tpl->execute([(int)$_POST['template_id']]);
+            $tpl = $tpl->fetch();
+            if (!$tpl) throw new RuntimeException('القالب غير موجود أو موقوف.');
+            $start = $_POST['start_date'];
+            $end = date('Y-m-d', strtotime($start) + ($tpl['duration_weeks'] * 7 - 1) * 86400);
+            $pdo->beginTransaction();
+            $pdo->prepare("INSERT INTO workout_plans (member_id, coach_id, goal_type, phase, start_date, end_date, status, notes)
+                           VALUES (?,?,?,?,?,?,'active',?)")->execute([
+                $targetMember, $coachId ?: null, $tpl['goal_type'], $tpl['phase'], $start, $end,
+                'من قالب: ' . $tpl['title'],
+            ]);
+            $planId = (int)$pdo->lastInsertId();
+            $tss = $pdo->prepare("SELECT * FROM template_sessions WHERE template_id = ? ORDER BY day_offset");
+            $tss->execute([$tpl['template_id']]);
+            $tss = $tss->fetchAll();
+            $insS = $pdo->prepare("INSERT INTO workout_sessions (workout_plan_id, session_date, muscle_group, completion_status, notes)
+                                   VALUES (?,?,?,'planned',?)");
+            $insX = $pdo->prepare("INSERT INTO session_exercises (session_id, exercise_id, sort_order, sets, reps, rest_sec, notes)
+                                   VALUES (?,?,?,?,?,?,?)");
+            foreach ($tss as $ts) {
+                $tse = $pdo->prepare("SELECT * FROM template_session_exercises WHERE template_session_id = ? ORDER BY sort_order");
+                $tse->execute([$ts['template_session_id']]);
+                $tse = $tse->fetchAll();
+                for ($w = 0; $w < (int)$tpl['duration_weeks']; $w++) {
+                    $date = date('Y-m-d', strtotime($start) + ($w * 7 + (int)$ts['day_offset']) * 86400);
+                    $insS->execute([$planId, $date, $ts['muscle_group'], $ts['title']]);
+                    $sid = (int)$pdo->lastInsertId();
+                    foreach ($tse as $x) {
+                        $insX->execute([$sid, $x['exercise_id'], $x['sort_order'], $x['sets'], $x['reps'], $x['rest_sec'], $x['load_note']]);
+                    }
+                }
+            }
+            $pdo->commit();
         } elseif ($act === 'set_session_status') {
             $pdo->prepare("UPDATE workout_sessions SET completion_status = ? WHERE session_id = ?")
                 ->execute([$_POST['completion_status'], (int)$_POST['session_id']]);
@@ -248,6 +319,7 @@ if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
         header("Location: captains.php?coach={$coachId}&member={$memberId}&ok=1");
         exit;
     } catch (Throwable $e) {
+        if ($pdo && $pdo->inTransaction()) $pdo->rollBack();
         $error = str_contains($e->getMessage(), 'Duplicate entry')
             ? 'قيمة مكررة: الهاتف أو البريد مستخدم لعضو آخر بالفعل.'
             : 'تعذّر الحفظ: ' . $e->getMessage();
@@ -427,6 +499,49 @@ $miles = $pdo->prepare("SELECT * FROM milestones WHERE member_id = ? ORDER BY mi
 $miles->execute([$memberId]); $miles = $miles->fetchAll();
 $injuries = $pdo->prepare("SELECT * FROM injury_history WHERE member_id = ? ORDER BY injury_date DESC");
 $injuries->execute([$memberId]); $injuries = $injuries->fetchAll();
+// التمارين المُهيكلة لكل جلسات العضو
+$sessEx = [];
+$sx = $pdo->prepare("SELECT se.*, e.name AS ex_name FROM session_exercises se
+                     JOIN exercises e ON e.exercise_id = se.exercise_id
+                     JOIN workout_sessions ws ON ws.session_id = se.session_id
+                     JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                     WHERE wp.member_id = ? ORDER BY se.sort_order");
+$sx->execute([$memberId]);
+foreach ($sx as $r) $sessEx[$r['session_id']][] = $r;
+$exList = $pdo->query("SELECT exercise_id, name FROM exercises WHERE active = 1 ORDER BY name")->fetchAll();
+// تقدّم الأحمال: أقصى حمل لكل تمرين في كل تاريخ جلسة
+$loadSeries = [];
+$lp = $pdo->prepare("SELECT e.name, ws.session_date, MAX(se.load_kg) AS mx
+                     FROM session_exercises se
+                     JOIN exercises e ON e.exercise_id = se.exercise_id
+                     JOIN workout_sessions ws ON ws.session_id = se.session_id
+                     JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                     WHERE wp.member_id = ? AND se.load_kg IS NOT NULL
+                     GROUP BY e.exercise_id, e.name, ws.session_date ORDER BY ws.session_date");
+$lp->execute([$memberId]);
+foreach ($lp as $r) $loadSeries[$r['name']][] = [$r['session_date'], $r['mx']];
+$loadSeries = array_filter($loadSeries, fn($pts) => count($pts) >= 2);
+$loadSeries = array_slice($loadSeries, 0, 4, true);
+// الحجم التدريبي التقريبي (طن) لكل مجموعة عضلية: آخر 7 أيام مقابل الأسبوع السابق
+$tonnage = $pdo->prepare("SELECT e.muscle_group,
+        ROUND(SUM(CASE WHEN ws.session_date >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+              THEN COALESCE(se.sets,0)*CAST(se.reps AS UNSIGNED)*COALESCE(se.load_kg,0) ELSE 0 END)/1000, 2) AS t_now,
+        ROUND(SUM(CASE WHEN ws.session_date < DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+              THEN COALESCE(se.sets,0)*CAST(se.reps AS UNSIGNED)*COALESCE(se.load_kg,0) ELSE 0 END)/1000, 2) AS t_prev
+    FROM session_exercises se
+    JOIN exercises e ON e.exercise_id = se.exercise_id
+    JOIN workout_sessions ws ON ws.session_id = se.session_id
+    JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+    WHERE wp.member_id = ? AND ws.session_date >= DATE_SUB(CURDATE(), INTERVAL 14 DAY)
+    GROUP BY e.muscle_group HAVING t_now > 0 OR t_prev > 0 ORDER BY t_now DESC");
+$tonnage->execute([$memberId]);
+$tonnage = $tonnage->fetchAll();
+// قوالب نشطة + اقتراح حسب آخر تقييم
+$tplsActive = $pdo->query("SELECT template_id, title, goal_type, phase, duration_weeks FROM program_templates WHERE active = 1 ORDER BY template_id")->fetchAll();
+$lastRisk = $pdo->prepare("SELECT risk_score FROM assessments WHERE member_id = ? ORDER BY assessment_date DESC LIMIT 1");
+$lastRisk->execute([$memberId]);
+$lastRisk = $lastRisk->fetchColumn();
+$suggestPhase = $lastRisk === false ? null : ($lastRisk >= 80 ? 'corrective' : ($lastRisk >= 60 ? 'stabilization' : null));
 
 $crumb = '<a class="link" href="captains.php?coach=' . $coachId . '">' . h($coach['full_name']) . '</a> / <strong>' . h($member['full_name']) . '</strong>';
 echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.php">الكباتن</a> / ') . $crumb . '</div>';
@@ -501,6 +616,34 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
                   <input type="hidden" name="session_id" value="<?=$s['session_id']?>">
                   <button type="submit" style="background:none;border:0;color:#dc2626;cursor:pointer;font-size:13px">🗑</button>
                 </form></td></tr>
+              <tr><td colspan="5" style="background:#fbfcfe;padding:4px 10px">
+                <?php foreach ($sessEx[$s['session_id']] ?? [] as $x): ?>
+                  <span style="display:inline-flex;align-items:center;gap:4px;background:#eef2ff;border-radius:999px;padding:2px 10px;font-size:12px;margin:2px">
+                    <?=h($x['sort_order'])?>. <strong><?=h($x['ex_name'])?></strong>
+                    <?=h($x['sets'])?>×<?=h($x['reps'])?><?= $x['load_kg'] !== null ? ' @' . h($x['load_kg']) . 'كجم' : ($x['notes'] ? ' (' . h($x['notes']) . ')' : '') ?><?= $x['rpe'] ? ' RPE' . h($x['rpe']) : '' ?>
+                    <form method="post" style="margin:0;display:inline"><?=csrf_field()?>
+                      <input type="hidden" name="action" value="delete_session_exercise">
+                      <input type="hidden" name="session_exercise_id" value="<?=$x['session_exercise_id']?>">
+                      <button type="submit" style="background:none;border:0;color:#dc2626;cursor:pointer;font-size:11px">✕</button>
+                    </form>
+                  </span>
+                <?php endforeach; ?>
+                <details style="display:inline-block;vertical-align:middle"><summary class="link" style="cursor:pointer;font-size:12px">➕ تمرين مُهيكل</summary>
+                  <form class="frm" method="post"><?=csrf_field()?>
+                    <input type="hidden" name="action" value="add_session_exercise">
+                    <input type="hidden" name="session_id" value="<?=$s['session_id']?>">
+                    <div><label>التمرين</label><select name="exercise_id"><?php foreach ($exList as $e2): ?><option value="<?=$e2['exercise_id']?>"><?=h($e2['name'])?></option><?php endforeach; ?></select></div>
+                    <div><label>ترتيب</label><input type="number" name="sort_order" value="1" min="1"></div>
+                    <div><label>مجموعات</label><input type="number" name="sets" min="1"></div>
+                    <div><label>تكرارات</label><input name="reps" placeholder="8-12"></div>
+                    <div><label>الحمل (كجم)</label><input type="number" step="0.5" name="load_kg"></div>
+                    <div><label>راحة (ث)</label><input type="number" name="rest_sec"></div>
+                    <div><label>RPE</label><input type="number" name="rpe" min="1" max="10"></div>
+                    <div><label>ملاحظة</label><input name="notes"></div>
+                    <div><button type="submit">حفظ</button></div>
+                  </form>
+                </details>
+              </td></tr>
             <?php endforeach; ?>
           </table>
         <?php endif; ?>
@@ -521,6 +664,21 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
         </details>
       </div>
     <?php endforeach; ?>
+    <h3>📋 إسناد قالب جاهز (يولّد الجلسات والتمارين تلقائيًا)</h3>
+    <?php if (!$tplsActive): ?><div class="empty">لا توجد قوالب نشطة — أنشئ واحدًا من صفحة "التمارين والقوالب".</div><?php else: ?>
+    <form class="frm" method="post"><?=csrf_field()?>
+      <input type="hidden" name="action" value="assign_template">
+      <input type="hidden" name="member_id" value="<?=$memberId?>">
+      <div style="grid-column:span 2"><label>القالب</label><select name="template_id">
+        <?php foreach ($tplsActive as $tp): $sug = $suggestPhase !== null && $tp['phase'] === $suggestPhase; ?>
+          <option value="<?=$tp['template_id']?>" <?= $sug ? 'selected' : '' ?>><?=h($tp['title'])?> — <?=h($tp['phase'])?> (<?=h($tp['duration_weeks'])?> أسابيع)<?= $sug ? ' ⭐ مقترح' : '' ?></option>
+        <?php endforeach; ?></select></div>
+      <div><label>تاريخ البداية</label><input type="date" name="start_date" value="<?=date('Y-m-d')?>" required></div>
+      <div><button type="submit">إسناد وتوليد</button></div>
+    </form>
+    <?php if ($suggestPhase !== null): ?><p class="muted" style="font-size:12px;margin:6px 0 0">بناءً على آخر تقييم (خطر <?=h($lastRisk)?>) المرحلة المقترحة: <strong><?=h($suggestPhase)?></strong> ⭐</p><?php endif; ?>
+    <?php endif; ?>
+
     <h3>➕ إضافة برنامج تمرين جديد</h3>
     <form class="frm" method="post"><?=csrf_field()?>
       <input type="hidden" name="action" value="add_workout_plan">
@@ -744,6 +902,23 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
     <div><strong style="font-size:13px;color:#334155">الوزن والكتلة العضلية</strong><?=line_chart([$wSeries,$mSeries])?></div>
     <div><strong style="font-size:13px;color:#334155">نسبة الدهون</strong><?=line_chart([$fSeries])?></div>
   </div>
+
+  <?php if ($loadSeries):
+    $palette = ['#2563eb','#16a34a','#f59e0b','#db2777']; $pi = 0; $ser = [];
+    foreach ($loadSeries as $nm => $pts) $ser[] = ['label' => $nm, 'color' => $palette[$pi++ % 4], 'points' => $pts];
+  ?>
+  <h3>🏋️ تقدّم الأحمال (أقصى حمل بالكيلو لكل جلسة)</h3>
+  <?=line_chart($ser)?>
+  <?php endif; ?>
+
+  <?php if ($tonnage): ?>
+  <h3>📦 الحجم التدريبي التقريبي (طن) — آخر 7 أيام مقابل الأسبوع السابق</h3>
+  <table><tr><th>المجموعة العضلية</th><th>هذا الأسبوع</th><th>الأسبوع السابق</th><th>التغير</th></tr>
+  <?php foreach ($tonnage as $tn): $d = $tn['t_now'] - $tn['t_prev']; ?>
+    <tr><td><?=h($tn['muscle_group'])?></td><td><strong><?=h($tn['t_now'])?></strong></td><td class="muted"><?=h($tn['t_prev'])?></td>
+      <td style="color:<?= $d >= 0 ? '#16a34a' : '#dc2626' ?>;font-weight:600"><?= $d >= 0 ? '▲' : '▼' ?> <?=h(round(abs($d), 2))?></td></tr>
+  <?php endforeach; ?></table>
+  <?php endif; ?>
 
   <?php if ($prog): ?>
   <h3>السجلّ</h3>

--- a/xcamp-gym-sql/dashboard/db.php
+++ b/xcamp-gym-sql/dashboard/db.php
@@ -113,6 +113,7 @@ function page_head(string $title, string $active = ''): void {
   <nav>
     <?php if (is_manager()): ?><a href="index.php" class="<?= $active==='dash' ? 'active' : '' ?>">لوحة الإدارة</a><?php endif; ?>
     <a href="captains.php" class="<?= $active==='captains' ? 'active' : '' ?>">واجهة الكباتن</a>
+    <a href="templates.php" class="<?= $active==='templates' ? 'active' : '' ?>">التمارين والقوالب</a>
   </nav>
   <span class="sub">
     👤 <?=h($u['name'])?> (<?=h($u['role'])?>)

--- a/xcamp-gym-sql/dashboard/templates.php
+++ b/xcamp-gym-sql/dashboard/templates.php
@@ -1,0 +1,195 @@
+<?php
+// =============================================================================
+// Xcamp Gym — مكتبة التمارين وقوالب البرامج (مورد مشترك لكل الكباتن والإدارة)
+// =============================================================================
+require __DIR__ . '/db.php';
+$me = require_login();
+
+$GOALS  = ['fat_loss','muscle_gain','strength','rehab','performance','general_fitness'];
+$PHASES = ['corrective','stabilization','hypertrophy','strength','power','maintenance'];
+
+$error = null;
+try { $pdo = db(); } catch (Throwable $e) { $error = $e->getMessage(); }
+
+$openTpl = isset($_GET['tpl']) ? (int)$_GET['tpl'] : 0;
+
+if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    try {
+        csrf_check();
+        $act = $_POST['action'] ?? '';
+        if ($act === 'add_exercise') {
+            $pdo->prepare("INSERT INTO exercises (name, muscle_group, equipment, video_url) VALUES (?,?,?,?)")
+                ->execute([trim($_POST['name']), trim($_POST['muscle_group']),
+                           trim($_POST['equipment'] ?? '') ?: null, trim($_POST['video_url'] ?? '') ?: null]);
+        } elseif ($act === 'toggle_exercise') {
+            $pdo->prepare("UPDATE exercises SET active = 1 - active WHERE exercise_id = ?")->execute([(int)$_POST['exercise_id']]);
+        } elseif ($act === 'add_template') {
+            $pdo->prepare("INSERT INTO program_templates (title, goal_type, phase, duration_weeks, description, created_by) VALUES (?,?,?,?,?,?)")
+                ->execute([trim($_POST['title']), $_POST['goal_type'], $_POST['phase'],
+                           max(1, (int)$_POST['duration_weeks']), trim($_POST['description'] ?? '') ?: null,
+                           $me['role'] === 'coach' ? (int)$me['coach_id'] : null]);
+            $openTpl = (int)$pdo->lastInsertId();
+        } elseif ($act === 'toggle_template') {
+            $pdo->prepare("UPDATE program_templates SET active = 1 - active WHERE template_id = ?")->execute([(int)$_POST['template_id']]);
+        } elseif ($act === 'add_template_session') {
+            $pdo->prepare("INSERT INTO template_sessions (template_id, day_offset, title, muscle_group) VALUES (?,?,?,?)")
+                ->execute([(int)$_POST['template_id'], min(6, max(0, (int)$_POST['day_offset'])),
+                           trim($_POST['title'] ?? '') ?: null, trim($_POST['muscle_group'] ?? '') ?: null]);
+            $openTpl = (int)$_POST['template_id'];
+        } elseif ($act === 'delete_template_session') {
+            $openTpl = (int)$pdo->query("SELECT template_id FROM template_sessions WHERE template_session_id = " . (int)$_POST['template_session_id'])->fetchColumn();
+            $pdo->prepare("DELETE FROM template_sessions WHERE template_session_id = ?")->execute([(int)$_POST['template_session_id']]);
+        } elseif ($act === 'add_tse') {
+            $openTpl = (int)$pdo->query("SELECT template_id FROM template_sessions WHERE template_session_id = " . (int)$_POST['template_session_id'])->fetchColumn();
+            $pdo->prepare("INSERT INTO template_session_exercises (template_session_id, exercise_id, sort_order, sets, reps, load_note, rest_sec) VALUES (?,?,?,?,?,?,?)")
+                ->execute([(int)$_POST['template_session_id'], (int)$_POST['exercise_id'],
+                           max(1, (int)($_POST['sort_order'] ?: 1)),
+                           $_POST['sets'] !== '' ? (int)$_POST['sets'] : null,
+                           trim($_POST['reps'] ?? '') ?: null, trim($_POST['load_note'] ?? '') ?: null,
+                           $_POST['rest_sec'] !== '' ? (int)$_POST['rest_sec'] : null]);
+        } elseif ($act === 'delete_tse') {
+            $openTpl = (int)$pdo->query("SELECT ts.template_id FROM template_session_exercises t JOIN template_sessions ts ON ts.template_session_id = t.template_session_id WHERE t.tse_id = " . (int)$_POST['tse_id'])->fetchColumn();
+            $pdo->prepare("DELETE FROM template_session_exercises WHERE tse_id = ?")->execute([(int)$_POST['tse_id']]);
+        }
+        header("Location: templates.php" . ($openTpl ? "?tpl=$openTpl" : "") . "&ok=1");
+        exit;
+    } catch (Throwable $e) {
+        $error = str_contains($e->getMessage(), 'Duplicate entry')
+            ? 'الاسم مستخدم بالفعل.' : 'تعذّر الحفظ: ' . $e->getMessage();
+    }
+}
+
+page_head('التمارين والقوالب', 'templates');
+if ($error) { db_error_box($error); page_foot(); exit; }
+if (isset($_GET['ok'])) echo '<div class="flash">تم الحفظ بنجاح.</div>';
+
+function sel2(string $name, array $opts, string $cur = ''): string {
+    $h = "<select name=\"" . h($name) . "\">";
+    foreach ($opts as $o) $h .= "<option" . ($o === $cur ? " selected" : "") . ">" . h($o) . "</option>";
+    return $h . "</select>";
+}
+
+$exs = $pdo->query("SELECT * FROM exercises ORDER BY muscle_group, name")->fetchAll();
+$activeExs = array_values(array_filter($exs, fn($e) => $e['active']));
+$tpls = $pdo->query("SELECT t.*, c.full_name AS coach_name,
+                            (SELECT COUNT(*) FROM template_sessions ts WHERE ts.template_id = t.template_id) AS sess_cnt
+                     FROM program_templates t LEFT JOIN coaches c ON c.coach_id = t.created_by
+                     ORDER BY t.template_id")->fetchAll();
+?>
+
+<section>
+  <h2>🏋️ مكتبة التمارين (<?=count($activeExs)?> نشط)</h2>
+  <table>
+    <tr><th>التمرين</th><th>المجموعة</th><th>الأداة</th><th>فيديو</th><th></th></tr>
+    <?php foreach ($exs as $e): ?>
+      <tr style="<?= $e['active'] ? '' : 'opacity:.5' ?>">
+        <td><strong><?=h($e['name'])?></strong></td><td><?=h($e['muscle_group'])?></td><td class="muted"><?=h($e['equipment'])?></td>
+        <td><?php if ($e['video_url']): ?><a class="link" href="<?=h($e['video_url'])?>" target="_blank">▶</a><?php else: ?><span class="muted">—</span><?php endif; ?></td>
+        <td><form method="post" style="margin:0"><?=csrf_field()?>
+          <input type="hidden" name="action" value="toggle_exercise"><input type="hidden" name="exercise_id" value="<?=$e['exercise_id']?>">
+          <button type="submit" style="background:<?= $e['active'] ? '#f59e0b' : '#16a34a' ?>;color:#fff;border:0;padding:3px 10px;border-radius:6px;font-size:11px;cursor:pointer"><?= $e['active'] ? '⏸' : '▶' ?></button>
+        </form></td></tr>
+    <?php endforeach; ?>
+  </table>
+  <h3>➕ إضافة تمرين</h3>
+  <form class="frm" method="post"><?=csrf_field()?>
+    <input type="hidden" name="action" value="add_exercise">
+    <div><label>الاسم *</label><input name="name" required></div>
+    <div><label>المجموعة العضلية *</label><input name="muscle_group" required placeholder="legs / back / chest"></div>
+    <div><label>الأداة</label><input name="equipment"></div>
+    <div><label>رابط فيديو</label><input name="video_url" type="url"></div>
+    <div><button type="submit">إضافة</button></div>
+  </form>
+</section>
+
+<section>
+  <h2>📋 قوالب البرامج</h2>
+  <?php foreach ($tpls as $t): ?>
+    <div style="border:1px solid #eef2f7;border-radius:10px;padding:12px;margin-bottom:12px;<?= $t['active'] ? '' : 'opacity:.6' ?>">
+      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap">
+        <strong><?=h($t['title'])?></strong>
+        <span class="badge" style="background:#2563eb"><?=h($t['goal_type'])?></span>
+        <span class="badge"><?=h($t['phase'])?></span>
+        <span class="muted" style="font-size:12px"><?=h($t['duration_weeks'])?> أسابيع · <?=h($t['sess_cnt'])?> جلسات/أسبوع<?= $t['coach_name'] ? ' · ' . h($t['coach_name']) : '' ?></span>
+        <a class="link" style="margin-inline-start:auto;font-size:13px" href="templates.php?tpl=<?= $openTpl === (int)$t['template_id'] ? 0 : (int)$t['template_id'] ?>"><?= $openTpl === (int)$t['template_id'] ? 'إغلاق' : 'تفاصيل ⤵' ?></a>
+        <form method="post" style="margin:0"><?=csrf_field()?>
+          <input type="hidden" name="action" value="toggle_template"><input type="hidden" name="template_id" value="<?=$t['template_id']?>">
+          <button type="submit" style="background:<?= $t['active'] ? '#f59e0b' : '#16a34a' ?>;color:#fff;border:0;padding:3px 10px;border-radius:6px;font-size:11px;cursor:pointer"><?= $t['active'] ? '⏸ إيقاف' : '▶ تفعيل' ?></button>
+        </form>
+      </div>
+      <?php if ($t['description']): ?><div class="muted" style="font-size:12px;margin-top:4px"><?=h($t['description'])?></div><?php endif; ?>
+
+      <?php if ($openTpl === (int)$t['template_id']):
+        $tss = $pdo->prepare("SELECT * FROM template_sessions WHERE template_id = ? ORDER BY day_offset");
+        $tss->execute([$t['template_id']]); $tss = $tss->fetchAll();
+        $tseBy = [];
+        if ($tss) {
+            $ids = implode(',', array_map(fn($x) => (int)$x['template_session_id'], $tss));
+            foreach ($pdo->query("SELECT t.*, e.name AS ex_name FROM template_session_exercises t JOIN exercises e ON e.exercise_id = t.exercise_id WHERE t.template_session_id IN ($ids) ORDER BY t.sort_order") as $r)
+                $tseBy[$r['template_session_id']][] = $r;
+        }
+      ?>
+        <?php foreach ($tss as $ts): ?>
+          <div style="background:#f8fafc;border-radius:8px;padding:10px;margin-top:10px">
+            <div style="display:flex;gap:8px;align-items:center">
+              <strong style="font-size:13px"><?=h($ts['title'] ?: 'جلسة')?></strong>
+              <span class="muted" style="font-size:12px">اليوم <?=h($ts['day_offset'])?> من الأسبوع · <?=h($ts['muscle_group'])?></span>
+              <form method="post" style="margin:0;margin-inline-start:auto" onsubmit="return confirm('حذف جلسة القالب وتمارينها؟')"><?=csrf_field()?>
+                <input type="hidden" name="action" value="delete_template_session"><input type="hidden" name="template_session_id" value="<?=$ts['template_session_id']?>">
+                <button type="submit" style="background:none;border:0;color:#dc2626;cursor:pointer">🗑</button>
+              </form>
+            </div>
+            <?php if (!empty($tseBy[$ts['template_session_id']])): ?>
+              <table style="margin-top:6px"><tr><th>#</th><th>التمرين</th><th>مجموعات×تكرارات</th><th>الحمل</th><th>راحة</th><th></th></tr>
+              <?php foreach ($tseBy[$ts['template_session_id']] as $x): ?>
+                <tr><td><?=h($x['sort_order'])?></td><td><?=h($x['ex_name'])?></td>
+                  <td><?=h($x['sets'])?> × <?=h($x['reps'])?></td><td class="muted"><?=h($x['load_note'])?></td>
+                  <td class="muted"><?=h($x['rest_sec'])?>ث</td>
+                  <td><form method="post" style="margin:0"><?=csrf_field()?>
+                    <input type="hidden" name="action" value="delete_tse"><input type="hidden" name="tse_id" value="<?=$x['tse_id']?>">
+                    <button type="submit" style="background:none;border:0;color:#dc2626;cursor:pointer;font-size:12px">🗑</button>
+                  </form></td></tr>
+              <?php endforeach; ?></table>
+            <?php endif; ?>
+            <details style="margin-top:6px"><summary class="link" style="cursor:pointer;font-size:12px">➕ إضافة تمرين للجلسة</summary>
+              <form class="frm" method="post"><?=csrf_field()?>
+                <input type="hidden" name="action" value="add_tse">
+                <input type="hidden" name="template_session_id" value="<?=$ts['template_session_id']?>">
+                <div><label>التمرين</label><select name="exercise_id"><?php foreach ($activeExs as $e): ?><option value="<?=$e['exercise_id']?>"><?=h($e['name'])?></option><?php endforeach; ?></select></div>
+                <div><label>الترتيب</label><input type="number" name="sort_order" value="1" min="1"></div>
+                <div><label>مجموعات</label><input type="number" name="sets" min="1"></div>
+                <div><label>تكرارات</label><input name="reps" placeholder="8-12"></div>
+                <div><label>ملاحظة الحمل</label><input name="load_note" placeholder="متوسط / 60%"></div>
+                <div><label>راحة (ث)</label><input type="number" name="rest_sec"></div>
+                <div><button type="submit">إضافة</button></div>
+              </form>
+            </details>
+          </div>
+        <?php endforeach; ?>
+        <details style="margin-top:10px"><summary class="link" style="cursor:pointer;font-size:13px">➕ إضافة جلسة للقالب</summary>
+          <form class="frm" method="post"><?=csrf_field()?>
+            <input type="hidden" name="action" value="add_template_session">
+            <input type="hidden" name="template_id" value="<?=$t['template_id']?>">
+            <div><label>اليوم داخل الأسبوع (0–6)</label><input type="number" name="day_offset" min="0" max="6" value="0" required></div>
+            <div><label>العنوان</label><input name="title" placeholder="Push / Full Body A"></div>
+            <div><label>المجموعة</label><input name="muscle_group"></div>
+            <div><button type="submit">إضافة الجلسة</button></div>
+          </form>
+        </details>
+      <?php endif; ?>
+    </div>
+  <?php endforeach; ?>
+
+  <h3>➕ إنشاء قالب جديد</h3>
+  <form class="frm" method="post"><?=csrf_field()?>
+    <input type="hidden" name="action" value="add_template">
+    <div><label>العنوان *</label><input name="title" required></div>
+    <div><label>الهدف</label><?=sel2('goal_type',$GOALS,'general_fitness')?></div>
+    <div><label>المرحلة</label><?=sel2('phase',$PHASES,'stabilization')?></div>
+    <div><label>عدد الأسابيع</label><input type="number" name="duration_weeks" value="4" min="1" max="52"></div>
+    <div style="grid-column:1/-1"><label>الوصف</label><input name="description"></div>
+    <div><button type="submit">إنشاء القالب</button></div>
+  </form>
+</section>
+
+<?php page_foot();

--- a/xcamp-gym-sql/deploy.sh
+++ b/xcamp-gym-sql/deploy.sh
@@ -20,6 +20,7 @@ FILES=(
   "04_events.sql"
   "05_views.sql"
   "06_seed_data.sql"
+  "08_workout_v2.sql"
   "07_test_queries.sql"
 )
 

--- a/xcamp-gym-sql/run_all.sql
+++ b/xcamp-gym-sql/run_all.sql
@@ -10,6 +10,7 @@ SOURCE sql/05_views.sql;
 SET @seeding = 1;
 SOURCE sql/06_seed_data.sql;
 SET @seeding = NULL;
+SOURCE sql/08_workout_v2.sql;
 SOURCE sql/07_test_queries.sql;
 
 -- Restore the session state saved in 00_init.sql (valid here because run_all

--- a/xcamp-gym-sql/sql/08_workout_v2.sql
+++ b/xcamp-gym-sql/sql/08_workout_v2.sql
@@ -1,0 +1,154 @@
+-- =============================================================================
+-- xcamp-gym-sql : 08_workout_v2.sql  (ترقية إضافية — لا تمسّ المخطط الأصلي)
+-- -----------------------------------------------------------------------------
+-- المرحلة 1: هيكلة التمارين
+--   exercises            مكتبة التمارين (اسم/مجموعة عضلية/أداة/فيديو)
+--   session_exercises    تمارين كل جلسة بشكل مُهيكل (مجموعات/تكرارات/حمل/راحة/RPE)
+-- المرحلة 2: قوالب البرامج
+--   program_templates    قالب برنامج (هدف/مرحلة/أسابيع)
+--   template_sessions    جلسات القالب (إزاحة اليوم داخل الأسبوع، تتكرر أسبوعيًا)
+--   template_session_exercises  تمارين كل جلسة قالب
+--
+-- الملف قابل لإعادة التشغيل: CREATE IF NOT EXISTS + INSERT IGNORE بمعرّفات ثابتة.
+-- =============================================================================
+
+USE xcamp_gym;
+
+-- يضمن قراءة النصوص العربية في هذا الملف بشكل صحيح أيًّا كان ترميز العميل
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS exercises (
+  exercise_id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(120) NOT NULL UNIQUE,
+  muscle_group VARCHAR(80) NOT NULL,
+  equipment VARCHAR(120) NULL,
+  video_url VARCHAR(255) NULL,
+  notes TEXT NULL,
+  active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS session_exercises (
+  session_exercise_id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  session_id BIGINT UNSIGNED NOT NULL,
+  exercise_id BIGINT UNSIGNED NOT NULL,
+  sort_order TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  sets TINYINT UNSIGNED NULL,
+  reps VARCHAR(20) NULL,
+  load_kg DECIMAL(6,2) NULL,
+  rest_sec SMALLINT UNSIGNED NULL,
+  rpe TINYINT UNSIGNED NULL,
+  notes VARCHAR(255) NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_sessex_session FOREIGN KEY (session_id) REFERENCES workout_sessions(session_id)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_sessex_exercise FOREIGN KEY (exercise_id) REFERENCES exercises(exercise_id)
+    ON DELETE RESTRICT ON UPDATE CASCADE,
+  INDEX idx_sessex_session (session_id),
+  INDEX idx_sessex_exercise (exercise_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS program_templates (
+  template_id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  title VARCHAR(150) NOT NULL UNIQUE,
+  goal_type ENUM('fat_loss','muscle_gain','strength','rehab','performance','general_fitness') NOT NULL DEFAULT 'general_fitness',
+  phase ENUM('corrective','stabilization','hypertrophy','strength','power','maintenance') NOT NULL DEFAULT 'stabilization',
+  duration_weeks TINYINT UNSIGNED NOT NULL DEFAULT 4,
+  description TEXT NULL,
+  active TINYINT(1) NOT NULL DEFAULT 1,
+  created_by BIGINT UNSIGNED NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  CONSTRAINT fk_tpl_coach FOREIGN KEY (created_by) REFERENCES coaches(coach_id)
+    ON DELETE SET NULL ON UPDATE CASCADE
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS template_sessions (
+  template_session_id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  template_id BIGINT UNSIGNED NOT NULL,
+  day_offset TINYINT UNSIGNED NOT NULL DEFAULT 0,   -- 0..6 داخل الأسبوع، تتكرر كل أسبوع
+  title VARCHAR(120) NULL,
+  muscle_group VARCHAR(80) NULL,
+  notes VARCHAR(255) NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_tps_template FOREIGN KEY (template_id) REFERENCES program_templates(template_id)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  INDEX idx_tps_template (template_id)
+) ENGINE=InnoDB;
+
+CREATE TABLE IF NOT EXISTS template_session_exercises (
+  tse_id BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  template_session_id BIGINT UNSIGNED NOT NULL,
+  exercise_id BIGINT UNSIGNED NOT NULL,
+  sort_order TINYINT UNSIGNED NOT NULL DEFAULT 1,
+  sets TINYINT UNSIGNED NULL,
+  reps VARCHAR(20) NULL,
+  load_note VARCHAR(40) NULL,     -- "خفيف" / "60% 1RM" — الحمل الفعلي يُسجَّل وقت التنفيذ
+  rest_sec SMALLINT UNSIGNED NULL,
+  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  CONSTRAINT fk_tse_tsession FOREIGN KEY (template_session_id) REFERENCES template_sessions(template_session_id)
+    ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_tse_exercise FOREIGN KEY (exercise_id) REFERENCES exercises(exercise_id)
+    ON DELETE RESTRICT ON UPDATE CASCADE,
+  INDEX idx_tse_tsession (template_session_id)
+) ENGINE=InnoDB;
+
+-- -----------------------------------------------------------------------------
+-- مكتبة تمارين أساسية
+-- -----------------------------------------------------------------------------
+INSERT IGNORE INTO exercises (exercise_id, name, muscle_group, equipment) VALUES
+(1,  'Back Squat',        'legs',      'barbell'),
+(2,  'Deadlift',          'back',      'barbell'),
+(3,  'Bench Press',       'chest',     'barbell'),
+(4,  'Overhead Press',    'shoulders', 'barbell'),
+(5,  'Barbell Row',       'back',      'barbell'),
+(6,  'Pull-up',           'back',      'bodyweight'),
+(7,  'Dumbbell Lunge',    'legs',      'dumbbell'),
+(8,  'Leg Press',         'legs',      'machine'),
+(9,  'Lat Pulldown',      'back',      'machine'),
+(10, 'Dumbbell Curl',     'arms',      'dumbbell'),
+(11, 'Triceps Pushdown',  'arms',      'cable'),
+(12, 'Plank',             'core',      'bodyweight'),
+(13, 'Goblet Squat',      'legs',      'dumbbell'),
+(14, 'Hip Thrust',        'glutes',    'barbell'),
+(15, 'Seated Cable Row',  'back',      'cable');
+
+-- -----------------------------------------------------------------------------
+-- قالب جاهز: Full Body مبتدئ — 3 أيام × 4 أسابيع
+-- -----------------------------------------------------------------------------
+INSERT IGNORE INTO program_templates (template_id, title, goal_type, phase, duration_weeks, description) VALUES
+(1, 'Full Body مبتدئ — 3 أيام', 'general_fitness', 'stabilization', 4, 'برنامج تأسيسي لكامل الجسم، ثلاث جلسات أسبوعيًا.');
+
+INSERT IGNORE INTO template_sessions (template_session_id, template_id, day_offset, title, muscle_group) VALUES
+(1, 1, 0, 'Full Body A', 'full body'),
+(2, 1, 2, 'Full Body B', 'full body'),
+(3, 1, 4, 'Full Body C', 'full body');
+
+INSERT IGNORE INTO template_session_exercises (tse_id, template_session_id, exercise_id, sort_order, sets, reps, load_note, rest_sec) VALUES
+(1,  1, 13, 1, 3, '10-12', 'خفيف',  90),
+(2,  1, 3,  2, 3, '8-10',  'متوسط', 120),
+(3,  1, 15, 3, 3, '10-12', 'متوسط', 90),
+(4,  1, 12, 4, 3, '30s',   NULL,    60),
+(5,  2, 1,  1, 3, '8-10',  'متوسط', 120),
+(6,  2, 4,  2, 3, '8-10',  'متوسط', 120),
+(7,  2, 9,  3, 3, '10-12', 'متوسط', 90),
+(8,  2, 10, 4, 2, '12',    'خفيف',  60),
+(9,  3, 2,  1, 3, '5-6',   'متوسط', 180),
+(10, 3, 7,  2, 3, '10',    'خفيف',  90),
+(11, 3, 6,  3, 3, 'AMRAP', NULL,    120),
+(12, 3, 11, 4, 2, '12',    'خفيف',  60);
+
+-- -----------------------------------------------------------------------------
+-- بيانات مُهيكلة لجلسات الـ seed (لعرض رسم تقدّم الأحمال مباشرة)
+-- الجلسات 1و2 للعضو 1 (سكوات 60 ثم 65 كجم)، والجلسة 4 للعضو 5
+-- -----------------------------------------------------------------------------
+INSERT IGNORE INTO session_exercises (session_exercise_id, session_id, exercise_id, sort_order, sets, reps, load_kg, rest_sec, rpe) VALUES
+(1, 1, 13, 1, 3, '12', 20.00,  90, 6),
+(2, 1, 3,  2, 3, '10', 40.00, 120, 7),
+(3, 1, 1,  3, 3, '10', 60.00, 120, 7),
+(4, 2, 1,  1, 3, '8',  65.00, 150, 8),
+(5, 2, 7,  2, 3, '10', 12.00,  90, 7),
+(6, 4, 2,  1, 5, '5', 120.00, 180, 8),
+(7, 4, 5,  2, 4, '8',  60.00, 120, 7);


### PR DESCRIPTION
## Summary

Implements **phases 1+2** of the workout-module roadmap: structured training data + program templates. The original 20-table schema is untouched — everything ships as an **additive migration** `sql/08_workout_v2.sql` (CREATE IF NOT EXISTS + INSERT IGNORE with fixed ids → fully re-runnable; `SET NAMES utf8mb4` so Arabic seed text loads correctly from any client), wired into `run_all.sql` and `deploy.sh`.

## Phase 1 — Structured exercises

- **`exercises`** — exercise library (name, muscle group, equipment, video URL); 15 common lifts seeded.
- **`session_exercises`** — per-session structured rows: order, sets, reps, **load_kg**, rest, RPE.
- **UI (captains.php)** — exercise chips under every session (`1. Back Squat 3×8 @65كجم RPE8 ✕`) + add form; delete per chip; ownership resolved session→plan→member.
- **🏆 PR detection** — inserting a load above the member's previous max for that exercise auto-creates a `strength_gain` milestone (badge); equal/lower loads don't duplicate.
- **📈 Load-progress chart** — max load per session per exercise (up to 4 series, SVG, no deps).
- **📦 Weekly tonnage table** — approximate volume (tons) per muscle group, last 7 days vs previous 7.

## Phase 2 — Program templates

- **`program_templates` + `template_sessions` (day_offset in a repeating week) + `template_session_exercises`**; one ready template seeded ("Full Body مبتدئ — 3 أيام", 3×week × 4 weeks).
- **`templates.php` (new page, nav-linked)** — exercise-library management (add/toggle) + template builder (template → weekly sessions → exercises per session).
- **One-click assignment** on the member page: pick template + start date → generates the plan + **all weekly sessions + their structured exercises** in one transaction.
- **⭐ Smart suggestion** — based on the member's latest assessment: risk ≥ 80 → `corrective` templates suggested; ≥ 60 → `stabilization` (preselected + starred).

## Verification (fresh MariaDB 10.11, PHP 8.4)

| Check | Result |
|---|---|
| Migration loads via run_all + re-run idempotent (15 exercises stay 15) | ✅ |
| Member page renders chips, load chart, assign form | ✅ |
| PR at 70 kg over previous 65 kg max → milestone; same load again → no duplicate | ✅ |
| Template assignment → 1 plan + **12 sessions + 48 structured exercises**, correct 4-week date range | ✅ |
| templates.php: add exercise / template / weekly session / session exercise | ✅ |
| Risk-82 member → `corrective` suggested + starred option | ✅ |
| Cross-coach session-exercise insert rejected | ✅ security |
| Arabic charset clean via PDO and page render | ✅ |

Screenshots captured during the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK

---
_Generated by [Claude Code](https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK)_