### PR TITLE
Phase 3 + load intelligence: coach calendar, live session mode, progressive-overload engine

### DIFF
--- a/xcamp-gym-sql/dashboard/calendar.php
+++ b/xcamp-gym-sql/dashboard/calendar.php
@@ -1,0 +1,93 @@
+<?php
+// =============================================================================
+// Xcamp Gym — تقويم الكابتن الأسبوعي: كل جلسات أعضائه في شبكة أيام (سبت→جمعة)
+// الكابتن يرى تقويمه فقط؛ المدير يختار الكابتن.
+// =============================================================================
+require __DIR__ . '/db.php';
+$me = require_login();
+
+$error = null;
+try { $pdo = db(); } catch (Throwable $e) { $error = $e->getMessage(); }
+
+$isCoach = ($me['role'] === 'coach');
+$coachId = $isCoach ? (int)($me['coach_id'] ?? 0) : (int)($_GET['coach'] ?? 0);
+
+page_head('التقويم', 'calendar');
+if ($error) { db_error_box($error); page_foot(); exit; }
+
+// المدير بدون كابتن محدد: اختيار
+if (!$coachId) {
+    $coaches = $pdo->query("SELECT coach_id, full_name FROM coaches WHERE active = 1 ORDER BY coach_id")->fetchAll();
+    echo '<section><h2>📅 اختر الكابتن لعرض تقويمه</h2><table><tr><th>#</th><th>الاسم</th><th></th></tr>';
+    foreach ($coaches as $c) {
+        echo '<tr><td>' . h($c['coach_id']) . '</td><td>' . h($c['full_name']) . '</td>' .
+             '<td><a class="link" href="calendar.php?coach=' . (int)$c['coach_id'] . '">عرض التقويم ←</a></td></tr>';
+    }
+    echo '</table></section>';
+    page_foot(); exit;
+}
+
+$coach = $pdo->prepare("SELECT full_name FROM coaches WHERE coach_id = ?");
+$coach->execute([$coachId]);
+$coachName = $coach->fetchColumn();
+if ($coachName === false) { echo '<div class="err">الكابتن غير موجود.</div>'; page_foot(); exit; }
+
+// بداية الأسبوع = السبت
+$ref = $_GET['week'] ?? date('Y-m-d');
+$ts  = strtotime($ref) ?: time();
+$dow = (int)date('w', $ts);                 // 0=أحد .. 6=سبت
+$satOffset = ($dow + 1) % 7;                // أيام منذ السبت
+$start = date('Y-m-d', $ts - $satOffset * 86400);
+$end   = date('Y-m-d', strtotime($start) + 6 * 86400);
+$prev  = date('Y-m-d', strtotime($start) - 7 * 86400);
+$next  = date('Y-m-d', strtotime($start) + 7 * 86400);
+$dayNames = ['السبت','الأحد','الاثنين','الثلاثاء','الأربعاء','الخميس','الجمعة'];
+
+$rows = $pdo->prepare("SELECT ws.session_id, ws.session_date, ws.muscle_group, ws.completion_status, ws.notes,
+                              m.member_id, m.full_name,
+                              (SELECT COUNT(*) FROM session_exercises se WHERE se.session_id = ws.session_id) AS ex_cnt
+                       FROM workout_sessions ws
+                       JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                       JOIN members m ON m.member_id = wp.member_id
+                       WHERE m.coach_id = ? AND ws.session_date BETWEEN ? AND ?
+                       ORDER BY ws.session_date, m.full_name");
+$rows->execute([$coachId, $start, $end]);
+$byDay = [];
+foreach ($rows as $r) $byDay[$r['session_date']][] = $r;
+
+$stColor = ['planned' => '#2563eb', 'completed' => '#16a34a', 'partial' => '#f59e0b', 'missed' => '#dc2626'];
+$coachQ = $isCoach ? '' : '&coach=' . $coachId;
+$total = 0; $done = 0;
+foreach ($byDay as $list) foreach ($list as $r) { $total++; if ($r['completion_status'] === 'completed') $done++; }
+?>
+<section>
+  <div style="display:flex;align-items:center;gap:12px;flex-wrap:wrap;margin-bottom:14px">
+    <h2 style="margin:0">📅 تقويم <?=h($coachName)?></h2>
+    <span class="muted" style="font-size:13px"><?=h($start)?> → <?=h($end)?> · <?=$total?> جلسة (<?=$done?> مكتملة)</span>
+    <span style="margin-inline-start:auto;display:flex;gap:8px">
+      <a class="link" href="calendar.php?week=<?=$prev?><?=$coachQ?>">→ الأسبوع السابق</a>
+      <a class="link" href="calendar.php<?= $coachQ ? '?' . ltrim($coachQ, '&') : '' ?>">هذا الأسبوع</a>
+      <a class="link" href="calendar.php?week=<?=$next?><?=$coachQ?>">الأسبوع التالي ←</a>
+    </span>
+  </div>
+  <div style="display:grid;grid-template-columns:repeat(7,1fr);gap:8px">
+    <?php for ($i = 0; $i < 7; $i++):
+      $d = date('Y-m-d', strtotime($start) + $i * 86400);
+      $isToday = $d === date('Y-m-d');
+    ?>
+      <div style="background:<?= $isToday ? '#eff6ff' : '#f8fafc' ?>;border:1px solid <?= $isToday ? '#93c5fd' : '#eef2f7' ?>;border-radius:10px;padding:8px;min-height:110px">
+        <div style="font-size:12px;font-weight:700;color:#334155;margin-bottom:6px"><?=$dayNames[$i]?><br><span class="muted" style="font-weight:400"><?=h(substr($d, 5))?></span></div>
+        <?php foreach ($byDay[$d] ?? [] as $s): ?>
+          <a href="session.php?id=<?=$s['session_id']?>" style="display:block;text-decoration:none;background:#fff;border-right:4px solid <?=$stColor[$s['completion_status']] ?? '#6b7280'?>;border-radius:7px;padding:5px 8px;margin-bottom:5px;box-shadow:0 1px 2px rgba(0,0,0,.06)">
+            <div style="font-size:12px;font-weight:700;color:#0f172a"><?=h($s['full_name'])?></div>
+            <div style="font-size:11px;color:#64748b"><?=h($s['muscle_group'] ?? $s['notes'] ?? 'جلسة')?> · <?=h($s['ex_cnt'])?> تمارين</div>
+            <span class="badge" style="background:<?=$stColor[$s['completion_status']] ?? '#6b7280'?>;font-size:10px;padding:1px 8px"><?=h($s['completion_status'])?></span>
+          </a>
+        <?php endforeach; ?>
+        <?php if (empty($byDay[$d])): ?><div class="muted" style="font-size:11px">—</div><?php endif; ?>
+      </div>
+    <?php endfor; ?>
+  </div>
+  <p class="muted" style="font-size:12px;margin:12px 0 0">اضغط أي جلسة لفتح <strong>وضع بدء الجلسة</strong> وتسجيل الأداء الفعلي مباشرة.</p>
+</section>
+<?php page_foot();

--- a/xcamp-gym-sql/dashboard/captains.php
+++ b/xcamp-gym-sql/dashboard/captains.php
@@ -360,7 +360,11 @@ if (!$memberId) {
     $q = trim($_GET['q'] ?? '');
     $sql = "SELECT m.member_id, m.full_name, m.status, m.goal_summary,
                    (SELECT MAX(a.attendance_date) FROM daily_attendance a WHERE a.member_id = m.member_id AND a.attended = 1) AS last_att,
-                   (SELECT a2.risk_score FROM assessments a2 WHERE a2.member_id = m.member_id ORDER BY a2.assessment_date DESC LIMIT 1) AS risk
+                   (SELECT a2.risk_score FROM assessments a2 WHERE a2.member_id = m.member_id ORDER BY a2.assessment_date DESC LIMIT 1) AS risk,
+                   (SELECT SUM(ws.completion_status = 'completed') FROM workout_sessions ws JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                     WHERE wp.member_id = m.member_id AND ws.session_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 30 DAY) AND CURDATE()) AS comp_done,
+                   (SELECT COUNT(*) FROM workout_sessions ws JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                     WHERE wp.member_id = m.member_id AND ws.session_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 30 DAY) AND CURDATE()) AS comp_total
             FROM members m WHERE m.coach_id = ?";
     $args = [$coachId];
     if ($q !== '') { $sql .= " AND (m.full_name LIKE ? OR m.phone LIKE ?)"; $args[] = "%$q%"; $args[] = "%$q%"; }
@@ -377,11 +381,19 @@ if (!$memberId) {
        . '</form>';
     if (!$members) echo '<div class="empty">' . ($q !== '' ? 'لا نتائج مطابقة للبحث.' : 'لا يوجد أعضاء مسنَدون.') . '</div>';
     else {
-        echo '<table><tr><th>#</th><th>الاسم</th><th>الحالة</th><th>درجة الخطر</th><th>آخر حضور</th><th>الهدف</th><th></th></tr>';
+        echo '<table><tr><th>#</th><th>الاسم</th><th>الحالة</th><th>درجة الخطر</th><th>الالتزام (30ي)</th><th>آخر حضور</th><th>الهدف</th><th></th></tr>';
         foreach ($members as $m) {
             $riskColor = $m['risk'] === null ? '#94a3b8' : ($m['risk'] >= 80 ? '#dc2626' : ($m['risk'] >= 60 ? '#f59e0b' : '#16a34a'));
+            if ((int)$m['comp_total'] > 0) {
+                $pct = round(100 * (int)$m['comp_done'] / (int)$m['comp_total']);
+                $cColor = $pct >= 75 ? '#16a34a' : ($pct >= 50 ? '#f59e0b' : '#dc2626');
+                $compCell = '<strong style="color:' . $cColor . '">' . $pct . '%</strong> <span class="muted" style="font-size:11px">(' . (int)$m['comp_done'] . '/' . (int)$m['comp_total'] . ')</span>';
+            } else {
+                $compCell = '<span class="muted">—</span>';
+            }
             echo '<tr><td>' . h($m['member_id']) . '</td><td>' . h($m['full_name']) . '</td><td><span class="badge">' . h($m['status']) . '</span></td>' .
                  '<td><strong style="color:' . $riskColor . '">' . h($m['risk'] ?? '—') . '</strong></td>' .
+                 '<td>' . $compCell . '</td>' .
                  '<td class="muted">' . h($m['last_att'] ?? '—') . '</td><td class="muted">' . h($m['goal_summary']) .
                  '</td><td><a class="link" href="captains.php?coach=' . $coachId . '&member=' . (int)$m['member_id'] . '">فتح الملف ←</a></td></tr>';
         }
@@ -434,6 +446,14 @@ if (!$memberId) {
                               GROUP BY m.member_id, m.full_name ORDER BY review_date");
     $reviews->execute([$coachId]);
     $reviews = $reviews->fetchAll();
+    $comp = $pdo->prepare("SELECT SUM(ws.completion_status = 'completed') AS d, COUNT(*) AS t
+                           FROM workout_sessions ws
+                           JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                           JOIN members m ON m.member_id = wp.member_id
+                           WHERE m.coach_id = ? AND ws.session_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 30 DAY) AND CURDATE()");
+    $comp->execute([$coachId]);
+    $comp = $comp->fetch();
+    $compPct = ((int)($comp['t'] ?? 0)) > 0 ? round(100 * (int)$comp['d'] / (int)$comp['t']) . '%' : '—';
     $repCards = [
         ['أعضاء مسنَدون', $rep['total'] ?? 0, '#2563eb'],
         ['نشطون', $rep['active_cnt'] ?? 0, '#16a34a'],
@@ -442,6 +462,7 @@ if (!$memberId) {
         ['إنذارات مفتوحة', $rep['open_flags'] ?? 0, '#db2777'],
         ['زيارات آخر 7 أيام', $rep['visits_7d'] ?? 0, '#0891b2'],
         ['جلسات مكتملة (7 أيام)', $rep['done_sessions_7d'] ?? 0, '#16a34a'],
+        ['الالتزام (30 يوم)', $compPct, '#0891b2'],
     ];
     echo '<section><h2>📊 تقرير الكابتن</h2><div class="kpis" style="margin-bottom:8px">';
     foreach ($repCards as [$l, $n, $clr]) {
@@ -542,6 +563,12 @@ $lastRisk = $pdo->prepare("SELECT risk_score FROM assessments WHERE member_id = 
 $lastRisk->execute([$memberId]);
 $lastRisk = $lastRisk->fetchColumn();
 $suggestPhase = $lastRisk === false ? null : ($lastRisk >= 80 ? 'corrective' : ($lastRisk >= 60 ? 'stabilization' : null));
+// التزام العضو خلال 30 يومًا (جلسات مكتملة ÷ إجمالي الجلسات المستحقة)
+$mComp = $pdo->prepare("SELECT SUM(ws.completion_status = 'completed') AS d, COUNT(*) AS t
+                        FROM workout_sessions ws JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                        WHERE wp.member_id = ? AND ws.session_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 30 DAY) AND CURDATE()");
+$mComp->execute([$memberId]);
+$mComp = $mComp->fetch();
 
 $crumb = '<a class="link" href="captains.php?coach=' . $coachId . '">' . h($coach['full_name']) . '</a> / <strong>' . h($member['full_name']) . '</strong>';
 echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.php">الكباتن</a> / ') . $crumb . '</div>';
@@ -581,7 +608,13 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
 <div class="grid2">
   <!-- ===== برامج التمرين ===== -->
   <section>
-    <h2>🏋️ برامج التمرين</h2>
+    <h2>🏋️ برامج التمرين
+      <?php if ((int)($mComp['t'] ?? 0) > 0):
+        $mp = round(100 * (int)$mComp['d'] / (int)$mComp['t']);
+        $mpc = $mp >= 75 ? '#16a34a' : ($mp >= 50 ? '#f59e0b' : '#dc2626'); ?>
+        <span class="badge" style="background:<?=$mpc?>;margin-inline-start:6px">الالتزام <?=$mp?>% (<?=(int)$mComp['d']?>/<?=(int)$mComp['t']?>)</span>
+      <?php endif; ?>
+    </h2>
     <?php if (!$wplans): ?><div class="empty">لا توجد برامج بعد.</div><?php endif; ?>
     <?php foreach ($wplans as $p): ?>
       <div style="border:1px solid #eef2f7;border-radius:10px;padding:12px;margin-bottom:12px">
@@ -604,7 +637,7 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
         <?php $ss = $sessByPlan[$p['workout_plan_id']] ?? []; if ($ss): ?>
           <table style="margin-top:6px"><tr><th>التاريخ</th><th>المجموعة</th><th>تمارين</th><th>الحالة</th><th></th></tr>
             <?php foreach ($ss as $s): ?>
-              <tr><td><?=h($s['session_date'])?></td><td><?=h($s['muscle_group'])?></td><td class="muted"><?=h($s['exercises'])?></td>
+              <tr><td><a class="link" href="session.php?id=<?=$s['session_id']?>" title="فتح وضع بدء الجلسة">▶ <?=h($s['session_date'])?></a></td><td><?=h($s['muscle_group'])?></td><td class="muted"><?=h($s['exercises'])?></td>
                 <td><form method="post" style="margin:0;display:flex;gap:4px"><?=csrf_field()?>
                   <input type="hidden" name="action" value="set_session_status">
                   <input type="hidden" name="session_id" value="<?=$s['session_id']?>">

--- a/xcamp-gym-sql/dashboard/captains.php
+++ b/xcamp-gym-sql/dashboard/captains.php
@@ -557,6 +557,31 @@ $tonnage = $pdo->prepare("SELECT e.muscle_group,
     GROUP BY e.muscle_group HAVING t_now > 0 OR t_prev > 0 ORDER BY t_now DESC");
 $tonnage->execute([$memberId]);
 $tonnage = $tonnage->fetchAll();
+// ذكاء الأحمال: كل الأحمال المسجّلة لكل تمرين (الأحدث أولًا) لحساب الاتجاه/1RM/الثبات/المقترح
+$liRows = $pdo->prepare("SELECT e.exercise_id, e.name, se.load_kg, se.reps, se.rpe, ws.session_date
+                         FROM session_exercises se
+                         JOIN exercises e ON e.exercise_id = se.exercise_id
+                         JOIN workout_sessions ws ON ws.session_id = se.session_id
+                         JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                         WHERE wp.member_id = ? AND se.load_kg IS NOT NULL
+                         ORDER BY e.name, ws.session_date DESC, se.session_exercise_id DESC");
+$liRows->execute([$memberId]);
+$loadIntel = [];    // exercise_id => ['name','rows'=>[...]]
+foreach ($liRows as $r) {
+    $eid = (int)$r['exercise_id'];
+    if (!isset($loadIntel[$eid])) $loadIntel[$eid] = ['name' => $r['name'], 'rows' => []];
+    $loadIntel[$eid]['rows'][] = $r;
+}
+// إنذار تخفيف حمل (deload): متوسط آخر ~5 قيم RPE ≥ 9
+$rpeAvg = $pdo->prepare("SELECT AVG(rpe) FROM (
+                            SELECT se.rpe FROM session_exercises se
+                            JOIN workout_sessions ws ON ws.session_id = se.session_id
+                            JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                            WHERE wp.member_id = ? AND se.rpe IS NOT NULL
+                            ORDER BY ws.session_date DESC, se.session_exercise_id DESC LIMIT 5) t");
+$rpeAvg->execute([$memberId]);
+$rpeAvg = $rpeAvg->fetchColumn();
+$deload = $rpeAvg !== null && $rpeAvg !== false && (float)$rpeAvg >= 9;
 // قوالب نشطة + اقتراح حسب آخر تقييم
 $tplsActive = $pdo->query("SELECT template_id, title, goal_type, phase, duration_weeks FROM program_templates WHERE active = 1 ORDER BY template_id")->fetchAll();
 $lastRisk = $pdo->prepare("SELECT risk_score FROM assessments WHERE member_id = ? ORDER BY assessment_date DESC LIMIT 1");
@@ -921,6 +946,46 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
     <div><button type="submit">حفظ الإصابة</button></div>
   </form>
   <p class="muted" style="font-size:12px;margin:10px 0 0">شدة high/critical: توقَف برامج العضو النشطة ويتحوّل لـ paused مع إنذار injury ومهمة إحالة طبية عاجلة — تلقائيًا.</p>
+</section>
+
+<!-- ===== ذكاء الأحمال ===== -->
+<section>
+  <h2>🧠 ذكاء الأحمال</h2>
+  <?php if ($deload): ?>
+    <div style="background:#fef3c7;color:#92400e;padding:12px 16px;border-radius:10px;margin-bottom:14px;font-weight:600">
+      ⚠️ إنذار تحميل زائد — متوسط RPE لآخر جلسات = <?=h(round((float)$rpeAvg,1))?>/10. يُنصح بأسبوع تخفيف حمل (Deload): قلّل الأحمال ~10–20% أو عدد المجموعات.
+    </div>
+  <?php endif; ?>
+  <?php if (!$loadIntel): ?>
+    <div class="empty">لا توجد أحمال مسجّلة بعد. سجّل الأداء الفعلي من <strong>وضع بدء الجلسة</strong> لتظهر التحليلات والمقترحات.</div>
+  <?php else: ?>
+    <table>
+      <tr><th>التمرين</th><th>آخر حمل</th><th>المنطقة</th><th>1RM تقديري</th><th>الاتجاه</th><th>الحمل المقترح</th><th>ملاحظة</th></tr>
+      <?php foreach ($loadIntel as $li):
+        $rows = $li['rows']; $last = $rows[0];
+        $lastLd = (float)$last['load_kg'];
+        $lastRp = $last['rpe'] !== null ? (int)$last['rpe'] : null;
+        $repsI  = reps_to_int($last['reps']);
+        $orm    = epley_1rm($lastLd, $repsI);
+        $loadsDesc = array_map(fn($r) => (float)$r['load_kg'], $rows);
+        $best   = max($loadsDesc);
+        [$tArrow, $tColor, $tLabel] = load_trend($lastLd, $best);
+        $sug    = suggest_next_load($lastLd, $lastRp);
+        $plateau = is_plateau($loadsDesc);
+      ?>
+        <tr>
+          <td><strong><?=h($li['name'])?></strong></td>
+          <td><?=h($lastLd)?>كجم × <?=h($last['reps'])?><?= $lastRp !== null ? ' <span class="muted">@RPE '.$lastRp.'</span>' : '' ?></td>
+          <td><span class="muted"><?=h(load_zone($repsI))?></span></td>
+          <td><?= $orm !== null ? '<strong>'.h($orm).'</strong> كجم' : '<span class="muted">—</span>' ?></td>
+          <td style="color:<?=$tColor?>;font-weight:700"><?=$tArrow?> <span style="font-weight:400;font-size:12px"><?=h($tLabel)?></span></td>
+          <td><?php if ($sug['load'] !== null): ?><span style="background:<?=$sug['color']?>;color:#fff;padding:2px 10px;border-radius:999px;font-weight:700"><?=h($sug['load'])?>كجم</span><?php else: ?><span class="muted">—</span><?php endif; ?></td>
+          <td style="font-size:12px;color:<?=$sug['color']?>"><?=h($sug['reason'])?><?php if ($plateau): ?> <span style="background:#fef3c7;color:#92400e;padding:1px 8px;border-radius:999px;font-weight:700">⚠️ ثبات</span><?php endif; ?></td>
+        </tr>
+      <?php endforeach; ?>
+    </table>
+    <p class="muted" style="font-size:12px;margin:10px 0 0">القواعد: 1RM بمعادلة Epley · المقترح من آخر RPE (≤6 زد ~5% · 7 ‎+2.5% · 8 ثبّت · ≥9 خفّف ~5%) · الثبات = 3 جلسات بلا زيادة.</p>
+  <?php endif; ?>
 </section>
 
 <!-- ===== متابعة التقدّم ===== -->

--- a/xcamp-gym-sql/dashboard/db.php
+++ b/xcamp-gym-sql/dashboard/db.php
@@ -6,6 +6,8 @@
 
 if (session_status() === PHP_SESSION_NONE) session_start();
 
+require_once __DIR__ . '/training.php';   // ذكاء الأحمال: دوال الحسابات التدريبية
+
 function h($v) { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }
 
 function db(): PDO {

--- a/xcamp-gym-sql/dashboard/db.php
+++ b/xcamp-gym-sql/dashboard/db.php
@@ -113,6 +113,7 @@ function page_head(string $title, string $active = ''): void {
   <nav>
     <?php if (is_manager()): ?><a href="index.php" class="<?= $active==='dash' ? 'active' : '' ?>">لوحة الإدارة</a><?php endif; ?>
     <a href="captains.php" class="<?= $active==='captains' ? 'active' : '' ?>">واجهة الكباتن</a>
+    <a href="calendar.php" class="<?= $active==='calendar' ? 'active' : '' ?>">التقويم</a>
     <a href="templates.php" class="<?= $active==='templates' ? 'active' : '' ?>">التمارين والقوالب</a>
   </nav>
   <span class="sub">

--- a/xcamp-gym-sql/dashboard/session.php
+++ b/xcamp-gym-sql/dashboard/session.php
@@ -1,0 +1,154 @@
+<?php
+// =============================================================================
+// Xcamp Gym — وضع "بدء الجلسة" الحي: تسجيل الأداء الفعلي تمرينًا بتمرين
+// أثناء التمرين، ثم إنهاء الجلسة (مع تسجيل حضور تلقائي عند الإكمال).
+// =============================================================================
+require __DIR__ . '/db.php';
+$me = require_login();
+
+$error = null;
+try { $pdo = db(); } catch (Throwable $e) { $error = $e->getMessage(); }
+
+$sid = (int)($_GET['id'] ?? 0);
+
+// جلب الجلسة + العضو والتحقق من الصلاحية
+$sess = null;
+if ($pdo && !$error && $sid) {
+    $q = $pdo->prepare("SELECT ws.*, wp.member_id, wp.goal_type, wp.phase, m.full_name, m.coach_id AS member_coach
+                        FROM workout_sessions ws
+                        JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                        JOIN members m ON m.member_id = wp.member_id
+                        WHERE ws.session_id = ?");
+    $q->execute([$sid]);
+    $sess = $q->fetch();
+}
+$denied = $sess && $me['role'] === 'coach' && (int)$sess['member_coach'] !== (int)($me['coach_id'] ?? 0);
+
+if ($pdo && !$error && $sess && !$denied && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    try {
+        csrf_check();
+        $act = $_POST['action'] ?? '';
+        if ($act === 'save_ex') {
+            $xid  = (int)$_POST['session_exercise_id'];
+            // تأكد أن التمرين تابع لهذه الجلسة
+            $own = $pdo->prepare("SELECT exercise_id FROM session_exercises WHERE session_exercise_id = ? AND session_id = ?");
+            $own->execute([$xid, $sid]);
+            $exId = $own->fetchColumn();
+            if ($exId === false) throw new RuntimeException('التمرين غير تابع لهذه الجلسة.');
+            $load = $_POST['load_kg'] !== '' ? (float)$_POST['load_kg'] : null;
+            // اكتشاف الرقم القياسي (مستثنيًا هذا الصف نفسه)
+            if ($load !== null) {
+                $pm = $pdo->prepare("SELECT MAX(se.load_kg) FROM session_exercises se
+                                     JOIN workout_sessions ws ON ws.session_id = se.session_id
+                                     JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                                     WHERE wp.member_id = ? AND se.exercise_id = ? AND se.session_exercise_id <> ?");
+                $pm->execute([(int)$sess['member_id'], (int)$exId, $xid]);
+                $prev = $pm->fetchColumn();
+                if ($prev !== null && $prev !== false && $load > (float)$prev) {
+                    $exName = $pdo->query("SELECT name FROM exercises WHERE exercise_id = " . (int)$exId)->fetchColumn();
+                    $pdo->prepare("INSERT INTO milestones (member_id, milestone_date, milestone_type, description, reward_status)
+                                   VALUES (?, CURDATE(), 'strength_gain', ?, 'badge')")
+                        ->execute([(int)$sess['member_id'], "🏆 رقم قياسي جديد في {$exName}: {$load} كجم (السابق: {$prev})"]);
+                }
+            }
+            $pdo->prepare("UPDATE session_exercises SET sets = ?, reps = ?, load_kg = ?, rpe = ?, notes = ? WHERE session_exercise_id = ?")
+                ->execute([
+                    $_POST['sets'] !== '' ? (int)$_POST['sets'] : null,
+                    trim($_POST['reps'] ?? '') ?: null, $load,
+                    $_POST['rpe'] !== '' ? (int)$_POST['rpe'] : null,
+                    trim($_POST['notes'] ?? '') ?: null, $xid,
+                ]);
+        } elseif ($act === 'finish') {
+            $st = $_POST['status'] ?? '';
+            if (!in_array($st, ['completed','partial','missed'], true)) throw new RuntimeException('حالة غير صالحة.');
+            $pdo->prepare("UPDATE workout_sessions SET completion_status = ? WHERE session_id = ?")->execute([$st, $sid]);
+            // عند الإكمال (كليًا/جزئيًا): سجّل حضور اليوم تلقائيًا إن لم يكن مسجّلًا
+            if (in_array($st, ['completed','partial'], true)) {
+                $dup = $pdo->prepare("SELECT 1 FROM daily_attendance WHERE member_id = ? AND attendance_date = ?");
+                $dup->execute([(int)$sess['member_id'], $sess['session_date']]);
+                if (!$dup->fetchColumn()) {
+                    $pdo->prepare("INSERT INTO daily_attendance (member_id, coach_id, attendance_date, check_in_time, attended, session_type, notes)
+                                   VALUES (?,?,?,CURTIME(),1,'training','سُجّل تلقائيًا من وضع بدء الجلسة')")
+                        ->execute([(int)$sess['member_id'], (int)$sess['member_coach'] ?: null, $sess['session_date']]);
+                }
+            }
+        }
+        header("Location: session.php?id={$sid}&ok=1");
+        exit;
+    } catch (Throwable $e) {
+        $error = 'تعذّر الحفظ: ' . $e->getMessage();
+    }
+}
+
+page_head('بدء الجلسة', 'calendar');
+if ($error && !$sess) { db_error_box($error); page_foot(); exit; }
+if (!$sess)  { echo '<div class="err">الجلسة غير موجودة.</div>'; page_foot(); exit; }
+if ($denied) { echo '<div class="err">غير مسموح — الجلسة لعضو كابتن آخر.</div>'; page_foot(); exit; }
+if ($error)  { echo '<div class="err">' . h($error) . '</div>'; }
+if (isset($_GET['ok'])) echo '<div class="flash">تم الحفظ.</div>';
+
+// إعادة الجلب بعد أي حفظ
+$exs = $pdo->prepare("SELECT se.*, e.name AS ex_name, e.muscle_group AS ex_group
+                      FROM session_exercises se JOIN exercises e ON e.exercise_id = se.exercise_id
+                      WHERE se.session_id = ? ORDER BY se.sort_order");
+$exs->execute([$sid]);
+$exs = $exs->fetchAll();
+$q = $pdo->prepare("SELECT completion_status FROM workout_sessions WHERE session_id = ?");
+$q->execute([$sid]);
+$curStatus = $q->fetchColumn();
+$stColor = ['planned' => '#2563eb', 'completed' => '#16a34a', 'partial' => '#f59e0b', 'missed' => '#dc2626'];
+$memberCoach = (int)$sess['member_coach'];
+?>
+<div class="crumb">
+  <a class="link" href="calendar.php<?= $me['role'] === 'coach' ? '' : '?coach=' . $memberCoach ?>">التقويم</a> /
+  <a class="link" href="captains.php?coach=<?=$memberCoach?>&member=<?=(int)$sess['member_id']?>"><?=h($sess['full_name'])?></a> /
+  <strong>جلسة <?=h($sess['session_date'])?></strong>
+</div>
+
+<section>
+  <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap">
+    <h2 style="margin:0">▶️ <?=h($sess['full_name'])?> — <?=h($sess['muscle_group'] ?? 'جلسة')?></h2>
+    <span class="badge" style="background:<?=$stColor[$curStatus] ?? '#6b7280'?>"><?=h($curStatus)?></span>
+    <span class="muted" style="font-size:13px"><?=h($sess['session_date'])?> · <?=h($sess['goal_type'])?> / <?=h($sess['phase'])?></span>
+  </div>
+</section>
+
+<?php if (!$exs): ?>
+  <section><div class="empty">لا توجد تمارين مُهيكلة لهذه الجلسة — أضِفها من صفحة العضو.</div></section>
+<?php endif; ?>
+
+<?php foreach ($exs as $i => $x): ?>
+<section style="padding:14px 18px">
+  <form method="post" style="margin:0"><?=csrf_field()?>
+    <input type="hidden" name="action" value="save_ex">
+    <input type="hidden" name="session_exercise_id" value="<?=$x['session_exercise_id']?>">
+    <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px">
+      <strong style="font-size:16px"><?=($i+1)?>. <?=h($x['ex_name'])?></strong>
+      <span class="muted" style="font-size:12px"><?=h($x['ex_group'])?><?= $x['rest_sec'] ? ' · راحة ' . h($x['rest_sec']) . 'ث' : '' ?><?= $x['notes'] && $x['load_kg'] === null ? ' · حمل مقترح: ' . h($x['notes']) : '' ?></span>
+    </div>
+    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:8px;align-items:end">
+      <div><label style="font-size:11px;color:#475569;display:block">مجموعات</label><input type="number" name="sets" value="<?=h($x['sets'])?>" min="1" style="width:100%;padding:8px;border:1px solid #cbd5e1;border-radius:8px;font-size:15px"></div>
+      <div><label style="font-size:11px;color:#475569;display:block">تكرارات</label><input name="reps" value="<?=h($x['reps'])?>" style="width:100%;padding:8px;border:1px solid #cbd5e1;border-radius:8px;font-size:15px"></div>
+      <div><label style="font-size:11px;color:#475569;display:block">الحمل الفعلي (كجم)</label><input type="number" step="0.5" name="load_kg" value="<?=h($x['load_kg'])?>" style="width:100%;padding:8px;border:2px solid #2563eb;border-radius:8px;font-size:15px;font-weight:700"></div>
+      <div><label style="font-size:11px;color:#475569;display:block">RPE</label><input type="number" name="rpe" value="<?=h($x['rpe'])?>" min="1" max="10" style="width:100%;padding:8px;border:1px solid #cbd5e1;border-radius:8px;font-size:15px"></div>
+      <div><label style="font-size:11px;color:#475569;display:block">ملاحظة</label><input name="notes" value="<?=h($x['notes'])?>" style="width:100%;padding:8px;border:1px solid #cbd5e1;border-radius:8px;font-size:13px"></div>
+      <div><button type="submit" style="background:#2563eb;color:#fff;border:0;padding:10px 16px;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer;width:100%">💾 حفظ</button></div>
+    </div>
+  </form>
+</section>
+<?php endforeach; ?>
+
+<section>
+  <h2>🏁 إنهاء الجلسة</h2>
+  <div style="display:flex;gap:10px;flex-wrap:wrap">
+    <?php foreach ([['completed','✅ اكتملت','#16a34a'],['partial','🌓 جزئية','#f59e0b'],['missed','❌ لم يحضر','#dc2626']] as [$stv,$lbl,$clr]): ?>
+      <form method="post" style="margin:0;flex:1;min-width:140px"><?=csrf_field()?>
+        <input type="hidden" name="action" value="finish">
+        <input type="hidden" name="status" value="<?=$stv?>">
+        <button type="submit" style="background:<?=$clr?>;color:#fff;border:0;padding:14px;border-radius:10px;font-size:15px;font-weight:700;cursor:pointer;width:100%"><?=$lbl?></button>
+      </form>
+    <?php endforeach; ?>
+  </div>
+  <p class="muted" style="font-size:12px;margin:10px 0 0">"اكتملت" أو "جزئية": يُسجَّل حضور العضو لليوم تلقائيًا (إن لم يكن مسجّلًا) وتعمل أتمتة المتابعة. تسجيل حمل أعلى من الرقم السابق يولّد إنجاز 🏆 تلقائيًا.</p>
+</section>
+<?php page_foot();

--- a/xcamp-gym-sql/dashboard/session.php
+++ b/xcamp-gym-sql/dashboard/session.php
@@ -93,6 +93,22 @@ $exs = $pdo->prepare("SELECT se.*, e.name AS ex_name, e.muscle_group AS ex_group
                       WHERE se.session_id = ? ORDER BY se.sort_order");
 $exs->execute([$sid]);
 $exs = $exs->fetchAll();
+
+// سجلّ الأحمال السابقة لكل تمرين لهذا العضو (من جلسات أخرى، الأحدث أولًا) — لذكاء الأحمال
+$hist = [];
+if ($exs) {
+    $exIds = array_values(array_unique(array_map(fn($x) => (int)$x['exercise_id'], $exs)));
+    $ph = implode(',', array_fill(0, count($exIds), '?'));
+    $hq = $pdo->prepare("SELECT se.exercise_id, se.load_kg, se.reps, se.rpe, ws.session_date
+                         FROM session_exercises se
+                         JOIN workout_sessions ws ON ws.session_id = se.session_id
+                         JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                         WHERE wp.member_id = ? AND se.exercise_id IN ($ph)
+                           AND se.session_id <> ? AND se.load_kg IS NOT NULL
+                         ORDER BY ws.session_date DESC, se.session_exercise_id DESC");
+    $hq->execute(array_merge([(int)$sess['member_id']], $exIds, [$sid]));
+    foreach ($hq as $r) $hist[(int)$r['exercise_id']][] = $r;
+}
 $q = $pdo->prepare("SELECT completion_status FROM workout_sessions WHERE session_id = ?");
 $q->execute([$sid]);
 $curStatus = $q->fetchColumn();
@@ -117,7 +133,20 @@ $memberCoach = (int)$sess['member_coach'];
   <section><div class="empty">لا توجد تمارين مُهيكلة لهذه الجلسة — أضِفها من صفحة العضو.</div></section>
 <?php endif; ?>
 
-<?php foreach ($exs as $i => $x): ?>
+<?php
+foreach ($exs as $i => $x):
+  // ذكاء الأحمال: آخر أداء مسجّل لهذا التمرين + تقدير 1RM + الحمل المقترح
+  $rows   = $hist[(int)$x['exercise_id']] ?? [];
+  $last   = $rows[0] ?? null;
+  $lastLd = $last ? (float)$last['load_kg'] : null;
+  $lastRp = $last && $last['rpe'] !== null ? (int)$last['rpe'] : null;
+  $orm    = $last ? epley_1rm($lastLd, reps_to_int($last['reps'])) : null;
+  $sug    = suggest_next_load($lastLd, $lastRp);
+  $loadsDesc = array_map(fn($r) => (float)$r['load_kg'], $rows);
+  $best   = $loadsDesc ? max($loadsDesc) : null;
+  $plateau = is_plateau($loadsDesc);
+  [$tArrow, $tColor, $tLabel] = load_trend($lastLd, $best);
+?>
 <section style="padding:14px 18px">
   <form method="post" style="margin:0"><?=csrf_field()?>
     <input type="hidden" name="action" value="save_ex">
@@ -125,6 +154,23 @@ $memberCoach = (int)$sess['member_coach'];
     <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:8px">
       <strong style="font-size:16px"><?=($i+1)?>. <?=h($x['ex_name'])?></strong>
       <span class="muted" style="font-size:12px"><?=h($x['ex_group'])?><?= $x['rest_sec'] ? ' · راحة ' . h($x['rest_sec']) . 'ث' : '' ?><?= $x['notes'] && $x['load_kg'] === null ? ' · حمل مقترح: ' . h($x['notes']) : '' ?></span>
+    </div>
+    <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin-bottom:10px;padding:8px 10px;background:#f8fafc;border:1px solid #eef2f7;border-radius:8px;font-size:12px">
+      <span style="font-weight:700;color:#334155">🧠 ذكاء الأحمال:</span>
+      <?php if ($last): ?>
+        <span class="muted">آخر مرة: <strong style="color:#0f172a"><?=h($lastLd)?>كجم</strong>×<?=h($last['reps'])?><?= $lastRp !== null ? ' @RPE '.$lastRp : '' ?></span>
+        <?php if ($orm): ?><span class="muted">· 1RM≈<strong style="color:#0f172a"><?=h($orm)?></strong></span><?php endif; ?>
+        <span style="color:<?=$tColor?>">· <?=$tArrow?> <?=h($tLabel)?></span>
+      <?php else: ?>
+        <span class="muted">لا سجل سابق لهذا التمرين — سجّل الأداء لبدء التتبّع.</span>
+      <?php endif; ?>
+      <?php if ($sug['load'] !== null): ?>
+        <span style="margin-inline-start:auto;background:<?=$sug['color']?>;color:#fff;padding:3px 10px;border-radius:999px;font-weight:700">المقترح: <?=h($sug['load'])?>كجم</span>
+        <span style="color:<?=$sug['color']?>"><?=h($sug['reason'])?></span>
+      <?php else: ?>
+        <span style="margin-inline-start:auto;color:<?=$sug['color']?>"><?=h($sug['reason'])?></span>
+      <?php endif; ?>
+      <?php if ($plateau): ?><span style="background:#fef3c7;color:#92400e;padding:3px 10px;border-radius:999px;font-weight:700">⚠️ ثبات — غيّر المتغيرات</span><?php endif; ?>
     </div>
     <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(90px,1fr));gap:8px;align-items:end">
       <div><label style="font-size:11px;color:#475569;display:block">مجموعات</label><input type="number" name="sets" value="<?=h($x['sets'])?>" min="1" style="width:100%;padding:8px;border:1px solid #cbd5e1;border-radius:8px;font-size:15px"></div>

--- a/xcamp-gym-sql/dashboard/training.php
+++ b/xcamp-gym-sql/dashboard/training.php
@@ -1,0 +1,72 @@
+<?php
+// =============================================================================
+// Xcamp Gym — ذكاء الأحمال: دوال نقية للحسابات التدريبية (بدون قاعدة/جلسة)
+//   - تقدير 1RM (Epley)
+//   - المنطقة التدريبية حسب التكرارات
+//   - اقتراح الحمل التالي (Progressive Overload) من آخر أداء + RPE
+//   - كشف الثبات (Plateau) من سلسلة الأحمال
+// =============================================================================
+
+/** يستخرج أول عدد صحيح من نص التكرارات ("8-10" -> 8، "AMRAP" -> null) */
+function reps_to_int($reps): ?int {
+    if ($reps === null || $reps === '') return null;
+    return preg_match('/\d+/', (string)$reps, $m) ? (int)$m[0] : null;
+}
+
+/** تقدير أقصى قوة (1RM) بمعادلة Epley: load × (1 + reps/30) */
+function epley_1rm(?float $load, ?int $reps): ?float {
+    if (!$load || $load <= 0 || !$reps || $reps < 1) return null;
+    if ($reps === 1) return $load;
+    return round($load * (1 + $reps / 30), 1);
+}
+
+/** تقريب لأقرب 2.5 كجم (أصغر زيادة أطباق شائعة) */
+function round25(float $x): float { return round($x / 2.5) * 2.5; }
+
+/** المنطقة التدريبية حسب التكرارات */
+function load_zone(?int $reps): string {
+    if ($reps === null) return '';
+    if ($reps <= 5)  return 'قوة';
+    if ($reps <= 12) return 'تضخيم';
+    return 'تحمّل';
+}
+
+/**
+ * اقتراح الحمل التالي بناءً على آخر حمل + مجهود (RPE):
+ *   RPE ≤ 6  → زد ~5%   | RPE 7 → +2.5% | RPE 8 → ثبّت | RPE ≥ 9 → خفّف ~5%
+ * يرجّع ['load'=>?float, 'reason'=>string, 'color'=>string]
+ */
+function suggest_next_load(?float $lastLoad, ?int $lastRpe): array {
+    if ($lastLoad === null || $lastLoad <= 0)
+        return ['load' => null, 'reason' => 'سجّل حملًا أولًا', 'color' => '#94a3b8'];
+    if ($lastRpe === null)
+        return ['load' => $lastLoad, 'reason' => 'أضف RPE لاقتراح أدق', 'color' => '#6b7280'];
+    if ($lastRpe <= 6)
+        return ['load' => round25($lastLoad * 1.05), 'reason' => 'جهد منخفض — زد ~5%', 'color' => '#16a34a'];
+    if ($lastRpe == 7)
+        return ['load' => round25($lastLoad * 1.025), 'reason' => 'تقدّم تدريجي +2.5%', 'color' => '#16a34a'];
+    if ($lastRpe == 8)
+        return ['load' => $lastLoad, 'reason' => 'الحمل مثالي — ثبّت', 'color' => '#2563eb'];
+    return ['load' => round25($lastLoad * 0.95), 'reason' => 'جهد مرتفع — خفّف ~5%', 'color' => '#f59e0b'];
+}
+
+/**
+ * كشف الثبات: تُمرَّر أحمال آخر الجلسات (الأحدث أولًا).
+ * ثبات = 3 قيم متتالية أو أكثر بلا زيادة (الأحدث ≤ اللي قبله).
+ */
+function is_plateau(array $loadsDesc): bool {
+    $loadsDesc = array_values(array_filter($loadsDesc, fn($v) => $v !== null && $v !== ''));
+    if (count($loadsDesc) < 3) return false;
+    for ($i = 0; $i < 3 - 1; $i++) {
+        if ((float)$loadsDesc[$i] > (float)$loadsDesc[$i + 1]) return false; // فيه تحسّن
+    }
+    return true;
+}
+
+/** الاتجاه العام: مقارنة آخر حمل بأفضل حمل */
+function load_trend(?float $last, ?float $best): array {
+    if ($last === null || $best === null) return ['▬', '#94a3b8', ''];
+    if ($last >= $best) return ['▲', '#16a34a', 'في أفضل مستوى'];
+    if ($last >= $best * 0.95) return ['▬', '#f59e0b', 'قريب من الأفضل'];
+    return ['▼', '#dc2626', 'تحت الأفضل'];
+}


### PR DESCRIPTION
## Summary

Implements **phase 3** of the workout-module roadmap (the coach&#39;s operational day) **plus a rule-based load-intelligence layer** on top of the structured workout data. No schema changes — everything runs on the existing tables.

## 📅 Weekly calendar (`calendar.php`, nav-linked)

Saturday→Friday grid of **all the coach&#39;s members&#39; sessions**, status-colored cards (planned blue / completed green / partial amber / missed red), today highlighted, prev/this/next-week navigation, and a weekly done/total counter. Coaches see their own calendar; managers pick a coach. Every card opens the live session page.

## ▶️ Live &#34;start session&#34; mode (`session.php`)

Built for a tablet on the gym floor:
- One card per structured exercise: planned sets/reps, rest, suggested load — with a highlighted **actual-load** field, RPE, note, and per-exercise save.
- Saving a load above the member&#39;s previous max → **🏆 automatic `strength_gain` milestone** (same PR logic, excluding the row being edited).
- Big finish buttons: **✅ completed / 🌓 partial / ❌ missed**. Completed/partial **auto-records the member&#39;s attendance** for the session date (if not already recorded); repeated finishes never duplicate attendance.
- Coach ownership enforced — another coach&#39;s session is denied.

## 🧠 Load intelligence (`training.php`, woven into session + member pages)

A dependency-free, rule-based coaching layer over the logged loads:
- **`training.php`** — pure helpers: Epley 1RM estimate, rep-zone (قوة/تضخيم/تحمّل), round-to-2.5 kg, RPE-driven next-load suggestion, plateau detection over the load series, and trend vs. personal best. 17 unit assertions pass.
- **Per-exercise banner in the live session** — last load/reps/RPE, estimated 1RM, trend, and the suggested next load, computed from prior sessions (excluding the one being logged).
- **Member `🧠 ذكاء الأحمال` panel** — per-exercise last load, zone, 1RM, trend ▲/▬/▼, suggested next load, and a **plateau flag**; plus a **member-level deload advisory** when the average of the last ~5 RPEs is ≥ 9.

Suggestion rules: RPE ≤6 +~5% · 7 +2.5% · 8 hold · ≥9 −~5%. Plateau = 3+ non-improving sessions.

## 📊 Compliance (last 30 days: completed ÷ due sessions)

- Member-list column with color-coded percent (≥75 green, ≥50 amber, else red).
- Coach-report KPI card (overall across the coach&#39;s members).
- Member-page badge next to the workout-programs heading.
- Every session row on the member page links (▶) to the live session view.

## Verification (fresh MariaDB 10.11, PHP 8.4)

| Check | Result |
|---|---|
| Calendar shows the assigned template&#39;s session on the correct weekday; week nav renders | ✅ |
| Live save recorded actual load; PR milestone fired (70 kg over 60 kg previous max) | ✅ |
| Finish=completed → status set + attendance auto-created (`attended=1`) | ✅ automation |
| Repeated finish on the same date → no duplicate attendance | ✅ |
| Compliance shown in member list, coach report, and member page | ✅ |
| Cross-coach session access denied | ✅ security |
| 1RM / rep-zone / round-2.5 / RPE-suggestion / plateau / trend helpers | ✅ 17/17 unit tests |
| Live member page: suggested loads recompute after logging; plateau + deload banners render | ✅ |

Screenshots captured during the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK