### PR TITLE
Fix broken redirect on the templates page

### DIFF
--- a/xcamp-gym-sql/dashboard/templates.php
+++ b/xcamp-gym-sql/dashboard/templates.php
@@ -51,7 +51,7 @@ if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
             $openTpl = (int)$pdo->query("SELECT ts.template_id FROM template_session_exercises t JOIN template_sessions ts ON ts.template_session_id = t.template_session_id WHERE t.tse_id = " . (int)$_POST['tse_id'])->fetchColumn();
             $pdo->prepare("DELETE FROM template_session_exercises WHERE tse_id = ?")->execute([(int)$_POST['tse_id']]);
         }
-        header("Location: templates.php" . ($openTpl ? "?tpl=$openTpl" : "") . "&ok=1");
+        header("Location: templates.php?" . ($openTpl ? "tpl=$openTpl&" : "") . "ok=1");
         exit;
     } catch (Throwable $e) {
         $error = str_contains($e->getMessage(), 'Duplicate entry')


### PR DESCRIPTION
## Problem

On `dashboard/templates.php`, the post-save redirect was assembled as:

```php
header("Location: templates.php" . ($openTpl ? "?tpl=$openTpl" : "") . "&ok=1");
```

When **no template was open** (`$openTpl == 0`) — i.e. after **adding an exercise**, **toggling an exercise** on/off, or **toggling a template** — this produced `templates.php&ok=1`: a URL with **no `?`**. The server does not serve that as the templates page, so the user got bounced off the page (blank/broken). This is why &#34;تمارين القوالب مش شغالة&#34; — the exercise-library actions appeared not to work.

## Fix

Always start the query string with `?`:

```php
header("Location: templates.php?" . ($openTpl ? "tpl=$openTpl&" : "") . "ok=1");
```

One-line change; no schema or behavior change beyond the corrected URL.

## Verification (live MariaDB 10.11 + PHP 8.4)

| Action | Redirect before | Redirect after | Result |
|---|---|---|---|
| toggle_exercise (no open template) | `templates.php&ok=1` (bounce) | `templates.php?ok=1` | ✅ HTTP 200 |
| add_tse (template open) | `templates.php?tpl=1&ok=1` | `templates.php?tpl=1&ok=1` | ✅ HTTP 200 (unchanged) |

Screenshot confirmed: exercise library (15 exercises) and the Full Body A/B/C template sessions with their exercises all render, with the &#34;تم الحفظ بنجاح&#34; success flash. Scanned the rest of the dashboard — no other malformed `Location:` redirects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK

---
_Generated by [Claude Code](https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK)_