### PR TITLE
Add mbstring polyfills so the dashboard runs without the mbstring extension

### DIFF
--- a/xcamp-gym-sql/dashboard/db.php
+++ b/xcamp-gym-sql/dashboard/db.php
@@ -6,6 +6,29 @@
 
 if (session_status() === PHP_SESSION_NONE) session_start();
 
+// بدائل آمنة لدوال mbstring في حال عدم تثبيت الامتداد (utf8mb4-aware)
+if (!function_exists('mb_strtolower')) {
+    function mb_strtolower($s, $enc = null) { return strtolower((string)$s); }
+}
+if (!function_exists('mb_strlen')) {
+    function mb_strlen($s, $enc = null) {
+        return count(preg_split('//u', (string)$s, -1, PREG_SPLIT_NO_EMPTY) ?: []);
+    }
+}
+if (!function_exists('mb_substr')) {
+    function mb_substr($s, $start, $length = null, $enc = null) {
+        $chars = preg_split('//u', (string)$s, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        return implode('', array_slice($chars, $start, $length));
+    }
+}
+if (!function_exists('mb_strimwidth')) {
+    function mb_strimwidth($s, $start, $width, $marker = '', $enc = null) {
+        $chars = preg_split('//u', (string)$s, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+        $out = implode('', array_slice($chars, $start, $width));
+        return (count($chars) - $start > $width) ? $out . $marker : $out;
+    }
+}
+
 require_once __DIR__ . '/training.php';   // ذكاء الأحمال: دوال الحسابات التدريبية
 
 function h($v) { return htmlspecialchars((string)$v, ENT_QUOTES, 'UTF-8'); }


### PR DESCRIPTION
## Problem

On a PHP install **without the `mbstring` extension**, the dashboard crashes with:

```
Call to undefined function mb_strtolower()
```

- `login.php` calls `mb_strtolower($email)` (rate-limit key).
- `captains.php` calls `mb_strimwidth($content, 0, 60, '…')` (message preview).

## Fix

Add UTF-8-aware fallbacks in `db.php` for `mb_strtolower` / `mb_strlen` / `mb_substr` / `mb_strimwidth`, each guarded by `function_exists()` so the **native extension is still used when present** and the polyfills only kick in when it&#39;s missing.

The fallbacks split the string on `//u` (multibyte-safe), so Arabic content truncates on character boundaries instead of corrupting mid-byte.

## Verification (live MariaDB 10.11 + PHP 8.4)

- `php -l db.php` clean.
- With the extension present, guards no-op; `login.php` → 200, member page (which uses `mb_strimwidth`) → 200.
- Fallback truncation of an 86-char Arabic string → clean, valid UTF-8 with the `…` marker; `strtolower` lowercases the email correctly.

## Note

This makes the app resilient by default. Installing the extension is still the recommended production setup:

```bash
sudo apt-get install php-mbstring && sudo systemctl restart apache2   # or just re-run for php -S
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK

---
_Generated by [Claude Code](https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK)_