### PR TITLE
Deeper training intelligence: volume landmarks, progression plan, readiness score

### DIFF
--- a/xcamp-gym-sql/dashboard/captains.php
+++ b/xcamp-gym-sql/dashboard/captains.php
@@ -581,7 +581,34 @@ $rpeAvg = $pdo->prepare("SELECT AVG(rpe) FROM (
                             ORDER BY ws.session_date DESC, se.session_exercise_id DESC LIMIT 5) t");
 $rpeAvg->execute([$memberId]);
 $rpeAvg = $rpeAvg->fetchColumn();
-$deload = $rpeAvg !== null && $rpeAvg !== false && (float)$rpeAvg >= 9;
+$rpeAvg = ($rpeAvg === null || $rpeAvg === false) ? null : (float)$rpeAvg;
+$deload = $rpeAvg !== null && $rpeAvg >= 9;
+// الحجم التدريبي الأسبوعي (مجموعات/عضلة) خلال آخر 7 أيام — لحدود الحجم (MEV/MAV/MRV)
+$volRows = $pdo->prepare("SELECT e.muscle_group AS mg, SUM(COALESCE(se.sets,0)) AS sets
+                          FROM session_exercises se
+                          JOIN exercises e ON e.exercise_id = se.exercise_id
+                          JOIN workout_sessions ws ON ws.session_id = se.session_id
+                          JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                          WHERE wp.member_id = ? AND ws.session_date >= DATE_SUB(CURDATE(), INTERVAL 7 DAY)
+                          GROUP BY e.muscle_group HAVING sets > 0 ORDER BY sets DESC");
+$volRows->execute([$memberId]);
+$weeklyVolume = $volRows->fetchAll();
+// رقم الأسبوع الحالي داخل أحدث برنامج نشط (1-based) + عدد أسابيعه
+$curPlan = $pdo->prepare("SELECT start_date, end_date FROM workout_plans
+                          WHERE member_id = ? AND status = 'active'
+                          ORDER BY start_date DESC, workout_plan_id DESC LIMIT 1");
+$curPlan->execute([$memberId]);
+$curPlan = $curPlan->fetch();
+$planWeekIndex = 0; $planTotalWeeks = 0;
+if ($curPlan) {
+    $daysIn = (int)floor((strtotime('today') - strtotime($curPlan['start_date'])) / 86400);
+    $planWeekIndex = $daysIn < 0 ? 1 : (int)floor($daysIn / 7) + 1;
+    if ($curPlan['end_date']) {
+        $span = (int)floor((strtotime($curPlan['end_date']) - strtotime($curPlan['start_date'])) / 86400);
+        $planTotalWeeks = (int)ceil(($span + 1) / 7);
+        if ($planWeekIndex > $planTotalWeeks && $planTotalWeeks > 0) $planWeekIndex = $planTotalWeeks;
+    }
+}
 // قوالب نشطة + اقتراح حسب آخر تقييم
 $tplsActive = $pdo->query("SELECT template_id, title, goal_type, phase, duration_weeks FROM program_templates WHERE active = 1 ORDER BY template_id")->fetchAll();
 $lastRisk = $pdo->prepare("SELECT risk_score FROM assessments WHERE member_id = ? ORDER BY assessment_date DESC LIMIT 1");
@@ -946,6 +973,73 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
     <div><button type="submit">حفظ الإصابة</button></div>
   </form>
   <p class="muted" style="font-size:12px;margin:10px 0 0">شدة high/critical: توقَف برامج العضو النشطة ويتحوّل لـ paused مع إنذار injury ومهمة إحالة طبية عاجلة — تلقائيًا.</p>
+</section>
+
+<!-- ===== التخطيط الذكي ===== -->
+<?php
+// حساب المجاميع: عضلات الإفراط + عدد التمارين الثابتة (يُعاد استخدامها في مؤشر الجاهزية)
+$overloadedGroups = 0;
+foreach ($weeklyVolume as $v) { if (volume_status((int)$v['sets'])[2] === 'over') $overloadedGroups++; }
+$plateauCount = 0; $anyPlateau = false;
+foreach ($loadIntel as $li) {
+    $ld = array_map(fn($r) => (float)$r['load_kg'], $li['rows']);
+    if (is_plateau($ld)) { $plateauCount++; $anyPlateau = true; }
+}
+$plan = progression_plan($planWeekIndex, $rpeAvg, $anyPlateau);
+[$rScore, $rLabel, $rColor] = readiness_score($rpeAvg, $overloadedGroups, $plateauCount);
+$hasIntel = $weeklyVolume || $loadIntel;
+?>
+<section>
+  <h2>🗓️ التخطيط الذكي</h2>
+  <?php if (!$hasIntel): ?>
+    <div class="empty">تظهر خطة التدرّج ومؤشرات الحجم والتعافي بعد تسجيل أحمال فعلية للعضو.</div>
+  <?php else: ?>
+    <div class="grid2" style="margin-bottom:14px">
+      <!-- مؤشر الجاهزية -->
+      <div style="border:1px solid #eef2f7;border-radius:10px;padding:14px">
+        <strong style="font-size:13px;color:#334155">مؤشر الجاهزية للتعافي</strong>
+        <div style="display:flex;align-items:center;gap:12px;margin-top:8px">
+          <div style="font-size:32px;font-weight:800;color:<?=$rColor?>"><?=$rScore?><span style="font-size:15px;font-weight:600">/100</span></div>
+          <span class="badge" style="background:<?=$rColor?>"><?=h($rLabel)?></span>
+        </div>
+        <div style="height:8px;background:#eef2f7;border-radius:6px;margin-top:10px;overflow:hidden">
+          <div style="height:100%;width:<?=$rScore?>%;background:<?=$rColor?>"></div>
+        </div>
+        <p class="muted" style="font-size:11px;margin:8px 0 0">يُحسب من متوسط RPE + عضلات الإفراط + التمارين الثابتة.</p>
+      </div>
+      <!-- خطة الأسبوع القادم -->
+      <div style="border:1px solid #eef2f7;border-radius:10px;padding:14px">
+        <strong style="font-size:13px;color:#334155">خطة الأسبوع القادم<?= $planWeekIndex ? ' — الأسبوع ' . $planWeekIndex . ($planTotalWeeks ? '/' . $planTotalWeeks : '') : '' ?></strong>
+        <div style="margin-top:8px"><span class="badge" style="background:<?=$plan[2]?>;font-size:13px"><?=h($plan[0])?></span></div>
+        <p style="font-size:13px;color:#334155;margin:10px 0 0"><?=h($plan[1])?></p>
+        <?php if (!$curPlan): ?><p class="muted" style="font-size:11px;margin:6px 0 0">لا يوجد برنامج نشط — الخطة عامة حسب الإجهاد.</p><?php endif; ?>
+      </div>
+    </div>
+    <!-- حدود الحجم التدريبي -->
+    <h3>📊 الحجم الأسبوعي لكل عضلة (مجموعات) مقابل الحدود العلمية</h3>
+    <?php if (!$weeklyVolume): ?>
+      <div class="empty">لا توجد مجموعات مسجّلة خلال آخر 7 أيام.</div>
+    <?php else: ?>
+      <table>
+        <tr><th>العضلة</th><th>مجموعات/أسبوع</th><th>الحالة</th><th>المقياس (0–24)</th></tr>
+        <?php foreach ($weeklyVolume as $v): [$vl, $vc, $vz] = volume_status((int)$v['sets']); $pct = min(100, (int)$v['sets'] / 24 * 100); ?>
+          <tr>
+            <td><strong><?=h($v['mg'])?></strong></td>
+            <td><strong style="font-size:15px"><?=h($v['sets'])?></strong></td>
+            <td><span class="badge" style="background:<?=$vc?>"><?=h($vl)?></span></td>
+            <td style="min-width:160px">
+              <div style="position:relative;height:10px;background:#eef2f7;border-radius:6px">
+                <div style="height:100%;width:<?=$pct?>%;background:<?=$vc?>;border-radius:6px"></div>
+                <span style="position:absolute;top:-4px;right:<?=(1-10/24)*100?>%;width:1px;height:18px;background:#16a34a" title="MEV 10"></span>
+                <span style="position:absolute;top:-4px;right:<?=(1-20/24)*100?>%;width:1px;height:18px;background:#2563eb" title="MAV 20"></span>
+              </div>
+            </td>
+          </tr>
+        <?php endforeach; ?>
+      </table>
+      <p class="muted" style="font-size:12px;margin:8px 0 0">الحدود: أقل من <strong>10</strong> = تحت الأدنى الفعّال (MEV) · <strong>10–20</strong> مثالي · <strong>20–22</strong> قرب الأقصى (MAV) · أكثر من <strong>22</strong> = إفراط محتمل (MRV).</p>
+    <?php endif; ?>
+  <?php endif; ?>
 </section>
 
 <!-- ===== ذكاء الأحمال ===== -->

--- a/xcamp-gym-sql/dashboard/training.php
+++ b/xcamp-gym-sql/dashboard/training.php
@@ -70,3 +70,54 @@ function load_trend(?float $last, ?float $best): array {
     if ($last >= $best * 0.95) return ['▬', '#f59e0b', 'قريب من الأفضل'];
     return ['▼', '#dc2626', 'تحت الأفضل'];
 }
+
+// =============================================================================
+// ذكاء تدريبي أعمق: حدود الحجم + خطة التدرّج/التخفيف + مؤشر الجاهزية
+// =============================================================================
+
+/**
+ * حالة الحجم الأسبوعي لعضلة مقابل الحدود العلمية (بالمجموعات/أسبوع):
+ *   MEV≈10 (أدنى فعّال) · MAV≈20 (أعلى تكيّف) · MRV≈22 (أقصى تحمّل).
+ * يرجّع ['label','color','zone'] حيث zone ∈ low|optimal|high|over.
+ */
+function volume_status(int $sets): array {
+    if ($sets < 10) return ['أقل من المطلوب', '#f59e0b', 'low'];
+    if ($sets <= 20) return ['مثالي', '#16a34a', 'optimal'];
+    if ($sets <= 22) return ['قرب الحد الأقصى', '#2563eb', 'high'];
+    return ['إفراط محتمل', '#dc2626', 'over'];
+}
+
+/**
+ * خطة الأسبوع القادم حسب رقم الأسبوع في الدورة (1-based) + متوسط RPE + وجود ثبات.
+ * كل أسبوع رابع = تخفيف. يرجّع ['action','detail','color'].
+ */
+function progression_plan(int $weekIndex, ?float $avgRpe, bool $anyPlateau): array {
+    if ($weekIndex > 0 && $weekIndex % 4 === 0)
+        return ['تخفيف (Deload)', 'أسبوع تخفيف مجدول — قلّل الأحمال/الحجم ~40–50% للتعافي.', '#f59e0b'];
+    if ($avgRpe !== null && $avgRpe >= 9)
+        return ['تخفيف مبكر', 'الإجهاد مرتفع (RPE مرتفع) — أدرِج تخفيفًا قبل موعده.', '#dc2626'];
+    if ($anyPlateau)
+        return ['تغيير المتغيّرات', 'يوجد ثبات — غيّر التمرين أو نطاق التكرارات أو أسلوب التنفيذ.', '#2563eb'];
+    if ($avgRpe !== null && $avgRpe <= 7)
+        return ['زيادة الحمل/الحجم', 'الجهد منخفض — قدّم بزيادة الحمل أو مجموعة إضافية.', '#16a34a'];
+    return ['تقدّم تدريجي', 'حافظ على التدرّج الأسبوعي مع زيادة بسيطة في الحمل.', '#16a34a'];
+}
+
+/**
+ * مؤشر جاهزية العضو للتعافي (0–100) من متوسط RPE + عدد عضلات الإفراط + عدد الثبات.
+ * يرجّع ['score','label','color'].
+ */
+function readiness_score(?float $avgRpe, int $overloadedGroups, int $plateauCount): array {
+    $s = 100;
+    if ($avgRpe !== null) {
+        if ($avgRpe >= 9) $s -= 30;
+        elseif ($avgRpe >= 8) $s -= 12;
+        elseif ($avgRpe <= 6) $s += 0;
+    }
+    $s -= $overloadedGroups * 15;
+    $s -= $plateauCount * 8;
+    $s = max(0, min(100, $s));
+    if ($s >= 75) return [$s, 'جاهز للتقدّم', '#16a34a'];
+    if ($s >= 50) return [$s, 'تعافٍ متوسط', '#f59e0b'];
+    return [$s, 'يحتاج راحة/تخفيف', '#dc2626'];
+}


### PR DESCRIPTION
## Summary

Builds on the rule-based load intelligence with a strategic **🗓️ التخطيط الذكي** panel on the member page. Fully rule-based — no external services or API keys.

## `training.php` (pure, unit-tested)

- **`volume_status()`** — weekly working-set count per muscle vs. the science-based landmarks MEV (10) / MAV (20) / MRV (22) → `low / optimal / high / over`.
- **`progression_plan()`** — the next-week action, derived from the active program&#39;s week index (every 4th week = scheduled deload), the recent average RPE, and whether any lift is plateaued. Returns deload / early-deload / change-variables / increase / progress.
- **`readiness_score()`** — a 0–100 recovery-readiness score from average RPE, count of over-volume muscle groups, and count of plateaued lifts, with a label (جاهز / متوسط / يحتاج راحة).

## `captains.php`

New **🗓️ التخطيط الذكي** section on the member page:
- **Readiness gauge** (0–100) with a colored bar.
- **Next-week plan card** showing the active program&#39;s current week `N/total` and the recommended action.
- **Weekly volume table** per muscle group — set count, color-coded status badge, and a 0–24 scale bar with MEV/MAV markers.

Adds the supporting queries: weekly set-volume per muscle (last 7 days) and current-program week-index computation from the active plan&#39;s start date.

## Verification (live MariaDB 10.11 + PHP 8.4)

- 14 new unit assertions pass (volume thresholds, all progression branches, readiness math and labels).
- End-to-end: a member with **legs = 24 (over)**, **chest = 14 (optimal)**, **back = 6 (low)** sets and average RPE 8.6 rendered **readiness 73/100 (&#34;تعافٍ متوسط&#34;)**, **week 5/13 → &#34;تقدّم تدريجي&#34;**, and correct per-muscle statuses. Screenshot captured.
- `php -l` clean on both files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK

---
_Generated by [Claude Code](https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK)_