### PR TITLE
Phase 4 UX: tabbed member page, AJAX saves, mobile-responsive layout

### DIFF
--- a/xcamp-gym-sql/dashboard/account.php
+++ b/xcamp-gym-sql/dashboard/account.php
@@ -40,7 +40,7 @@ page_head('حسابي');
     <?php if ($flash): ?><div class="flash"><?=h($flash)?></div><?php endif; ?>
     <?php if ($error): ?><div class="err" style="margin:0 0 14px"><?=h($error)?></div><?php endif; ?>
     <h3>تغيير كلمة المرور</h3>
-    <form method="post" style="display:grid;gap:12px">
+    <form method="post" data-no-ajax style="display:grid;gap:12px">
       <?=csrf_field()?>
       <div><label style="font-size:13px;color:#475569;display:block;margin-bottom:4px">كلمة المرور الحالية</label>
         <input name="current_password" type="password" required style="width:100%;padding:9px 11px;border:1px solid #cbd5e1;border-radius:8px"></div>

--- a/xcamp-gym-sql/dashboard/captains.php
+++ b/xcamp-gym-sql/dashboard/captains.php
@@ -739,8 +739,17 @@ $crumb = '<a class="link" href="captains.php?coach=' . $coachId . '">' . h($coac
 echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.php">الكباتن</a> / ') . $crumb . '</div>';
 ?>
 
+<nav class="tabbar" aria-label="أقسام العضو">
+  <button type="button" data-tabtarget="overview">👤 نظرة عامة</button>
+  <button type="button" data-tabtarget="training">🏋️ التمرين</button>
+  <button type="button" data-tabtarget="nutrition">🥗 التغذية</button>
+  <button type="button" data-tabtarget="intel">🧠 الذكاء</button>
+  <button type="button" data-tabtarget="health">📈 الصحة والتقدّم</button>
+  <button type="button" data-tabtarget="followup">📆 المتابعة</button>
+</nav>
+
 <!-- ===== بيانات العضو ===== -->
-<section>
+<section data-tab="overview">
   <h2>👤 <?=h($member['full_name'])?>
     <span class="badge" style="margin-inline-start:6px"><?=h($member['status'])?></span>
   </h2>
@@ -770,9 +779,8 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
   </details>
 </section>
 
-<div class="grid2">
   <!-- ===== برامج التمرين ===== -->
-  <section>
+  <section data-tab="training">
     <h2>🏋️ برامج التمرين
       <?php if ((int)($mComp['t'] ?? 0) > 0):
         $mp = round(100 * (int)$mComp['d'] / (int)$mComp['t']);
@@ -893,7 +901,7 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
   </section>
 
   <!-- ===== التغذية ===== -->
-  <section>
+  <section data-tab="nutrition">
     <h2>🥗 خطط التغذية</h2>
     <?php if (!$nplans): ?><div class="empty">لا توجد خطط تغذية بعد.</div><?php endif; ?>
     <?php foreach ($nplans as $n): ?>
@@ -959,11 +967,8 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
       <div><button type="submit">إضافة مكمّل</button></div>
     </form>
   </section>
-</div>
-
-<div class="grid2">
   <!-- ===== التقييمات ===== -->
-  <section>
+  <section data-tab="health">
     <h2>🧪 التقييمات (تشغّل أتمتة الخطر)</h2>
     <?php if (!$assessments): ?><div class="empty">لا توجد تقييمات بعد.</div><?php else: ?>
       <table><tr><th>التاريخ</th><th>خطر</th><th>التصنيف</th><th>توصية</th><th>مراجعة قادمة</th></tr>
@@ -993,7 +998,7 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
   </section>
 
   <!-- ===== المتابعات ===== -->
-  <section>
+  <section data-tab="followup">
     <h2>☎️ المتابعات</h2>
     <?php if (!$fups): ?><div class="empty">لا توجد متابعات بعد.</div><?php else: ?>
       <table><tr><th>التاريخ</th><th>السبب</th><th>القناة</th><th>الرد</th><th>الإجراء</th></tr>
@@ -1018,10 +1023,9 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
     </form>
     <p class="muted" style="font-size:12px;margin:10px 0 0">no_response: تُفتح مهمة اتصال تلقائيًا · booked/converted: تُحلّ الإنذارات المفتوحة تلقائيًا.</p>
   </section>
-</div>
 
 <!-- ===== مهام وإنذارات العضو ===== -->
-<section>
+<section data-tab="followup">
   <h2>🗂️ المهام والإنذارات المفتوحة لهذا العضو</h2>
   <div class="grid2">
     <div>
@@ -1055,7 +1059,7 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
 </section>
 
 <!-- ===== سجل الإصابات ===== -->
-<section>
+<section data-tab="health">
   <h2>🩹 سجل الإصابات (يشغّل أتمتة الإيقاف)</h2>
   <?php if (!$injuries): ?><div class="empty">لا توجد إصابات مسجّلة.</div><?php else: ?>
     <table><tr><th>التاريخ</th><th>المنطقة</th><th>النوع</th><th>الشدة</th><th>الحالة + التصريح الطبي</th><th>ملاحظات</th></tr>
@@ -1089,7 +1093,7 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
 </section>
 
 <!-- ===== المولّد الذكي ===== -->
-<section>
+<section data-tab="intel">
   <h2>🤖 المولّد الذكي (برنامج + تغذية)</h2>
   <div class="grid2">
     <!-- توليد برنامج تدريبي -->
@@ -1178,7 +1182,7 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
 </section>
 
 <!-- ===== تتبّع الالتزام الغذائي ===== -->
-<section>
+<section data-tab="nutrition">
   <h2>📆 تتبّع الالتزام الغذائي</h2>
   <div class="grid2" style="margin-bottom:12px">
     <div style="border:1px solid #eef2f7;border-radius:10px;padding:14px">
@@ -1248,7 +1252,7 @@ $plan = progression_plan($planWeekIndex, $rpeAvg, $anyPlateau);
 [$rScore, $rLabel, $rColor] = readiness_score($rpeAvg, $overloadedGroups, $plateauCount);
 $hasIntel = $weeklyVolume || $loadIntel;
 ?>
-<section>
+<section data-tab="intel">
   <h2>🗓️ التخطيط الذكي</h2>
   <?php if (!$hasIntel): ?>
     <div class="empty">تظهر خطة التدرّج ومؤشرات الحجم والتعافي بعد تسجيل أحمال فعلية للعضو.</div>
@@ -1302,7 +1306,7 @@ $hasIntel = $weeklyVolume || $loadIntel;
 </section>
 
 <!-- ===== ذكاء الأحمال ===== -->
-<section>
+<section data-tab="intel">
   <h2>🧠 ذكاء الأحمال</h2>
   <?php if ($deload): ?>
     <div style="background:#fef3c7;color:#92400e;padding:12px 16px;border-radius:10px;margin-bottom:14px;font-weight:600">
@@ -1342,7 +1346,7 @@ $hasIntel = $weeklyVolume || $loadIntel;
 </section>
 
 <!-- ===== متابعة التقدّم ===== -->
-<section>
+<section data-tab="health">
   <h2>📈 متابعة التقدّم</h2>
   <?php
     $wSeries = ['label'=>'الوزن (kg)','color'=>'#2563eb','points'=>array_map(fn($r)=>[$r['record_date'],$r['weight']],$prog)];
@@ -1406,7 +1410,7 @@ $hasIntel = $weeklyVolume || $loadIntel;
 </section>
 
 <!-- ===== الحضور اليومي ===== -->
-<section>
+<section data-tab="followup">
   <h2>📅 الحضور اليومي (يشغّل أتمتة المتابعة)</h2>
   <?php if (!$att): ?><div class="empty">لا توجد سجلّات حضور بعد.</div><?php else: ?>
     <table><tr><th>التاريخ</th><th>الحالة</th><th>دخول</th><th>خروج</th><th>النوع</th><th>ملاحظات</th></tr>
@@ -1435,7 +1439,7 @@ $hasIntel = $weeklyVolume || $loadIntel;
 
 <div class="grid2">
   <!-- ===== الرسائل ===== -->
-  <section>
+  <section data-tab="followup">
     <h2>💬 سجلّ الرسائل</h2>
     <?php if (!$msgs): ?><div class="empty">لا توجد رسائل بعد.</div><?php else: ?>
       <table><tr><th>التاريخ</th><th>القناة</th><th>النوع</th><th>المحتوى</th><th>الحالة</th></tr>
@@ -1459,7 +1463,7 @@ $hasIntel = $weeklyVolume || $loadIntel;
   </section>
 
   <!-- ===== الإنجازات ===== -->
-  <section>
+  <section data-tab="followup">
     <h2>🏆 الإنجازات</h2>
     <?php if (!$miles): ?><div class="empty">لا توجد إنجازات بعد.</div><?php else: ?>
       <table><tr><th>التاريخ</th><th>النوع</th><th>الوصف</th><th>المكافأة</th></tr>

--- a/xcamp-gym-sql/dashboard/db.php
+++ b/xcamp-gym-sql/dashboard/db.php
@@ -94,7 +94,8 @@ function page_head(string $title, string $active = ''): void {
 <title><?=h($title)?> — Xcamp Gym</title>
 <style>
   * { box-sizing: border-box; }
-  body { margin:0; font-family: system-ui, "Segoe UI", Tahoma, sans-serif; background:#f1f5f9; color:#0f172a; }
+  html, body { overflow-x: hidden; }
+  body { margin:0; font-family: system-ui, "Segoe UI", Tahoma, sans-serif; background:#f1f5f9; color:#0f172a; max-width:100%; }
   header { background:#0f172a; color:#fff; padding:14px 24px; display:flex; align-items:center; gap:20px; flex-wrap:wrap; }
   header .brand { font-size:18px; font-weight:800; }
   header nav a { color:#cbd5e1; text-decoration:none; padding:6px 12px; border-radius:8px; font-size:14px; }
@@ -129,12 +130,43 @@ function page_head(string $title, string $active = ''): void {
   .err code { display:block; margin-top:8px; font-size:13px; opacity:.85; word-break:break-all; }
   .empty { color:#94a3b8; padding:10px 0; }
   .crumb { margin-bottom:16px; font-size:14px; }
+  /* ---- المرحلة 4: التبويبات ---- */
+  .tabbar { display:none; gap:6px; overflow-x:auto; background:#fff; border-radius:12px; padding:8px; margin-bottom:20px;
+            box-shadow:0 1px 3px rgba(0,0,0,.06); position:sticky; top:0; z-index:20; -webkit-overflow-scrolling:touch; }
+  .tabbar.ready { display:flex; }
+  .tabbar button { flex:0 0 auto; border:0; background:transparent; padding:9px 15px; border-radius:8px; font-size:14px;
+                   font-weight:600; color:#475569; cursor:pointer; white-space:nowrap; font-family:inherit; transition:background .12s,color .12s; }
+  .tabbar button:hover { background:#f1f5f9; }
+  .tabbar button.active { background:#2563eb; color:#fff; }
+  /* ---- المرحلة 4: زر قائمة الموبايل ---- */
+  .nav-toggle { display:none; background:#1e293b; color:#fff; border:0; border-radius:8px; padding:6px 12px; font-size:18px; cursor:pointer; line-height:1; }
+  /* ---- المرحلة 4: توست AJAX ---- */
+  .toast { position:fixed; inset-block-end:20px; inset-inline-start:50%; transform:translateX(50%) translateY(24px);
+           background:#0f172a; color:#fff; padding:12px 20px; border-radius:10px; font-size:14px; font-weight:600;
+           box-shadow:0 8px 24px rgba(0,0,0,.25); opacity:0; pointer-events:none; transition:opacity .2s, transform .2s; z-index:60; }
+  .toast.show { opacity:1; transform:translateX(50%) translateY(0); }
+  .toast.err { background:#991b1b; }
+  .ajax-busy { opacity:.6; pointer-events:none; }
+  /* ---- المرحلة 4: تحسينات الموبايل ---- */
+  @media (max-width:720px){
+    header { padding:12px 16px; gap:10px; }
+    header .brand { font-size:16px; }
+    header nav { display:none; flex-basis:100%; flex-direction:column; gap:4px; }
+    header.nav-open nav { display:flex; }
+    header .sub { flex-basis:100%; margin-inline-start:0; flex-wrap:wrap; gap:6px; font-size:11px; word-break:break-word; }
+    .nav-toggle { display:inline-block; margin-inline-start:auto; }
+    main { padding:14px; }
+    section { padding:14px; overflow-wrap:anywhere; }
+    section table { display:block; overflow-x:auto; white-space:nowrap; -webkit-overflow-scrolling:touch; }
+    form.frm { grid-template-columns:1fr 1fr; }
+  }
 </style>
 </head>
 <body>
 <header>
   <span class="brand">🏋️ Xcamp Gym</span>
   <?php if ($u): ?>
+  <button class="nav-toggle" type="button" aria-label="القائمة">☰</button>
   <nav>
     <?php if (is_manager()): ?><a href="index.php" class="<?= $active==='dash' ? 'active' : '' ?>">لوحة الإدارة</a><?php endif; ?>
     <a href="captains.php" class="<?= $active==='captains' ? 'active' : '' ?>">واجهة الكباتن</a>
@@ -153,7 +185,85 @@ function page_head(string $title, string $active = ''): void {
 <?php
 }
 
-function page_foot(): void { echo "</main></body></html>"; }
+function page_foot(): void {
+    echo "</main>";
+    page_script();
+    echo "</body></html>";
+}
+
+/** المرحلة 4: سكربت مشترك — قائمة الموبايل + التبويبات + حفظ AJAX (تحسين تدريجي) */
+function page_script(): void {
+    ?>
+<div class="toast" id="toast"></div>
+<script>
+(function(){
+  "use strict";
+  var header = document.querySelector('header');
+  var toggle = document.querySelector('.nav-toggle');
+  if (toggle && header) toggle.addEventListener('click', function(){ header.classList.toggle('nav-open'); });
+
+  function tabKey(){ return 'xtab:' + location.pathname + location.search; }
+  function bar(){ return document.querySelector('.tabbar'); }
+  function panels(){ return [].slice.call(document.querySelectorAll('main [data-tab]')); }
+  function tabBtns(){ var b = bar(); return b ? [].slice.call(b.querySelectorAll('[data-tabtarget]')) : []; }
+
+  function activate(name, save){
+    var btns = tabBtns(); if (!btns.length) return;
+    var valid = btns.some(function(t){ return t.getAttribute('data-tabtarget') === name; });
+    if (!valid) name = btns[0].getAttribute('data-tabtarget');
+    panels().forEach(function(s){ s.style.display = (s.getAttribute('data-tab') === name) ? '' : 'none'; });
+    btns.forEach(function(t){ t.classList.toggle('active', t.getAttribute('data-tabtarget') === name); });
+    if (save !== false){ try { sessionStorage.setItem(tabKey(), name); } catch(e){} }
+  }
+  function initTabs(){
+    var b = bar(); if (!b) return;
+    b.classList.add('ready');
+    tabBtns().forEach(function(t){
+      t.addEventListener('click', function(){ activate(t.getAttribute('data-tabtarget')); });
+    });
+    var stored = null; try { stored = sessionStorage.getItem(tabKey()); } catch(e){}
+    var want = (location.hash || '').replace('#','') || stored;
+    activate(want, false);
+  }
+  initTabs();
+
+  var toastEl = document.getElementById('toast'), toastT;
+  function toast(msg, isErr){
+    if (!toastEl) return;
+    toastEl.textContent = msg; toastEl.className = 'toast show' + (isErr ? ' err' : '');
+    clearTimeout(toastT); toastT = setTimeout(function(){ toastEl.className = 'toast' + (isErr ? ' err' : ''); }, 2600);
+  }
+
+  // حفظ AJAX: يعترض نماذج POST داخل main (عدا رفع الملفات ومن يطلب التخطّي)
+  document.addEventListener('submit', function(e){
+    var f = e.target;
+    if (!f || f.tagName !== 'FORM' || e.defaultPrevented) return;              // احترم confirm() الذي ألغى الإرسال
+    if ((f.method || '').toLowerCase() !== 'post') return;                     // نماذج GET (بحث) تعمل عاديًا
+    if ((f.enctype || '').indexOf('multipart') !== -1) return;                 // رفع الملفات: إرسال عادي
+    if (f.hasAttribute('data-no-ajax') || !f.closest('main')) return;
+    e.preventDefault();
+    var main = document.querySelector('main');
+    var btn = f.querySelector('button[type=submit], button:not([type])');
+    if (btn) btn.disabled = true;
+    main.classList.add('ajax-busy');
+    fetch(f.action || location.href, { method:'POST', body:new FormData(f), redirect:'follow', headers:{'X-Requested-With':'fetch'} })
+      .then(function(r){ return r.text(); })
+      .then(function(html){
+        var doc = new DOMParser().parseFromString(html, 'text/html');
+        var nm = doc.querySelector('main');
+        if (!nm) throw new Error('no main');
+        var errBox = nm.querySelector('.err');
+        main.innerHTML = nm.innerHTML;
+        main.classList.remove('ajax-busy');
+        initTabs();
+        toast(errBox ? errBox.textContent.trim().slice(0,80) : 'تم الحفظ ✓', !!errBox);
+      })
+      .catch(function(){ main.classList.remove('ajax-busy'); if (btn) btn.disabled = false; f.submit(); });
+  });
+})();
+</script>
+    <?php
+}
 
 function db_error_box(string $msg): void {
     ?>

--- a/xcamp-gym-sql/dashboard/login.php
+++ b/xcamp-gym-sql/dashboard/login.php
@@ -77,7 +77,7 @@ page_head('تسجيل الدخول');
   <section>
     <h2 style="text-align:center">🔐 تسجيل دخول الموظفين</h2>
     <?php if ($error): ?><div class="err" style="margin:0 0 14px"><?=h($error)?></div><?php endif; ?>
-    <form method="post" style="display:grid;gap:12px">
+    <form method="post" data-no-ajax style="display:grid;gap:12px">
       <?=csrf_field()?>
       <div><label style="font-size:13px;color:#475569;display:block;margin-bottom:4px">البريد الإلكتروني</label>
         <input name="email" type="email" required autofocus style="width:100%;padding:9px 11px;border:1px solid #cbd5e1;border-radius:8px"></div>


### PR DESCRIPTION
## Summary

A progressive-enhancement UX layer over the dashboard: **tabs**, **AJAX saves**, and a **mobile-responsive** layout. Everything degrades gracefully — with JavaScript off, all sections show and every form submits normally.

## `db.php` (shared)

- **Responsive CSS**: mobile hamburger nav, a horizontally-scrollable sticky tab bar, stacked grids, scrollable tables, an AJAX toast, and a body `overflow-x` guard.
- **`page_foot()` now emits `page_script()`** — one small vanilla-JS bundle:
  - **Mobile nav** toggle (hamburger).
  - **Tab controller**: shows/hides sections by `data-tab`; the active tab is persisted per-page in `sessionStorage` and restorable from the URL hash.
  - **AJAX form handler**: intercepts in-page POST forms, submits via `fetch`, swaps `<main>`, keeps the active tab, and toasts success/error — it **skips file uploads and `data-no-ajax` forms**, respects a `confirm()` cancel, and **falls back to a normal submit** on any failure.

## `captains.php`

- Member page organized into **6 tabs** — 👤 نظرة عامة / 🏋️ التمرين / 🥗 التغذية / 🧠 الذكاء / 📈 الصحة والتقدّم / 📆 المتابعة — via a sticky tab bar; each section tagged with `data-tab`.
- Unwrapped two `grid2` pairs that straddled tab boundaries so every section is full-width and cleanly assignable to one tab.

## `login.php` / `account.php`

- Auth forms marked `data-no-ajax` (they navigate across pages).

## Verification (live MariaDB 10.11 + PHP 8.4)

- **Tabs (real browser):** initial view shows only the overview section; clicking التغذية reveals exactly the 2 nutrition sections and hides the rest; active state + `ready` class correct.
- **Mobile:** hamburger + scrollable tab bar render; measured `scrollWidth == innerWidth` (no horizontal overflow at the layout width).
- **Forms:** a normal POST still `302`-redirects and saves; an AJAX-style POST returns the success page for the main-swap; invalid input surfaces the error box (which AJAX shows as an error toast).
- Every dashboard page (`index`, `calendar`, `templates`, `captains`, `session`, `account`) renders with **no PHP errors**; `php -l` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK

---
_Generated by [Claude Code](https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK)_