### PR TITLE
Member Portal: self-service login, workout logging, nutrition, progress, renewals

### DIFF
--- a/xcamp-gym-sql/dashboard/captains.php
+++ b/xcamp-gym-sql/dashboard/captains.php
@@ -189,6 +189,14 @@ if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
                     trim($_POST['notes'] ?? '') ?: null,
                     $targetMember,
                 ]);
+        } elseif ($act === 'set_member_portal') {
+            // تفعيل/إعادة تعيين كلمة مرور بوابة العضو
+            $pw = (string)($_POST['portal_password'] ?? '');
+            if (strlen($pw) < 6) throw new RuntimeException('كلمة مرور البوابة يجب أن تكون 6 أحرف على الأقل.');
+            $hash = password_hash($pw, PASSWORD_BCRYPT);
+            $pdo->prepare("INSERT INTO member_auth (member_id, password_hash, portal_enabled) VALUES (?,?,1)
+                           ON DUPLICATE KEY UPDATE password_hash = VALUES(password_hash), portal_enabled = 1")
+                ->execute([$targetMember, $hash]);
         } elseif ($act === 'add_injury') {
             // إدخال الإصابة يشغّل sp_handle_injury_event عبر الـ trigger
             // (high/critical: إيقاف برامج العضو + العضو paused + إنذار injury + مهمة إحالة طبية عاجلة)
@@ -776,6 +784,15 @@ echo '<div class="crumb">' . ($isCoach ? '' : '<a class="link" href="captains.ph
       <div style="grid-column:1/-1"><label>ملاحظات</label><input name="notes" value="<?=h($member['notes'])?>"></div>
       <div><button type="submit">حفظ التعديلات</button></div>
     </form>
+  </details>
+  <details style="margin-top:8px"><summary class="link" style="cursor:pointer;font-size:13px">🔑 بوابة العضو (تفعيل / إعادة تعيين كلمة المرور)</summary>
+    <form class="frm" method="post" style="margin-top:8px"><?=csrf_field()?>
+      <input type="hidden" name="action" value="set_member_portal">
+      <input type="hidden" name="member_id" value="<?=$memberId?>">
+      <div style="grid-column:1/-1"><label>كلمة مرور البوابة (٦ أحرف على الأقل)</label><input name="portal_password" minlength="6" required></div>
+      <div><button type="submit">تفعيل البوابة</button></div>
+    </form>
+    <p class="muted" style="font-size:11px;margin:6px 0 0">يدخل العضو من <code>member_login.php</code> بالهاتف أو البريد + كلمة المرور دي.</p>
   </details>
 </section>
 

--- a/xcamp-gym-sql/dashboard/db.php
+++ b/xcamp-gym-sql/dashboard/db.php
@@ -68,6 +68,14 @@ function is_manager(): bool {
     return $u && in_array($u['role'], ['admin','manager','reception'], true);
 }
 
+// ---- مصادقة العضو (بوابة العضو — منفصلة عن الموظّفين) ----
+function current_member(): ?array { return $_SESSION['member'] ?? null; }
+function require_member(): array {
+    $m = current_member();
+    if (!$m) { header('Location: member_login.php'); exit; }
+    return $m;
+}
+
 // ---- حماية CSRF ----
 function csrf_token(): string {
     if (empty($_SESSION['csrf'])) $_SESSION['csrf'] = bin2hex(random_bytes(32));
@@ -92,6 +100,37 @@ function page_head(string $title, string $active = ''): void {
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title><?=h($title)?> — Xcamp Gym</title>
+<?php page_styles(); ?>
+</head>
+<body>
+<header>
+  <span class="brand">🏋️ Xcamp Gym</span>
+  <?php if ($u): ?>
+  <button class="nav-toggle" type="button" aria-label="القائمة">☰</button>
+  <nav>
+    <?php if (is_manager()): ?><a href="index.php" class="<?= $active==='dash' ? 'active' : '' ?>">لوحة الإدارة</a><?php endif; ?>
+    <a href="captains.php" class="<?= $active==='captains' ? 'active' : '' ?>">واجهة الكباتن</a>
+    <a href="crm.php" class="<?= $active==='crm' ? 'active' : '' ?>">CRM</a>
+    <a href="retention.php" class="<?= $active==='retention' ? 'active' : '' ?>">الاحتفاظ</a>
+    <a href="revenue.php" class="<?= $active==='revenue' ? 'active' : '' ?>">الإيرادات</a>
+    <a href="calendar.php" class="<?= $active==='calendar' ? 'active' : '' ?>">التقويم</a>
+    <a href="templates.php" class="<?= $active==='templates' ? 'active' : '' ?>">التمارين والقوالب</a>
+  </nav>
+  <span class="sub">
+    👤 <?=h($u['name'])?> (<?=h($u['role'])?>)
+    · <a href="account.php" style="color:#93c5fd">حسابي</a>
+    · <a href="logout.php">خروج</a>
+    · <span style="color:#475569">قاعدة: <?=h($db)?></span>
+  </span>
+  <?php endif; ?>
+</header>
+<main>
+<?php
+}
+
+/** كتلة الأنماط المشتركة (تُستخدم في رأس الموظّفين ورأس العضو) */
+function page_styles(): void {
+    ?>
 <style>
   * { box-sizing: border-box; }
   html, body { overflow-x: hidden; }
@@ -161,28 +200,26 @@ function page_head(string $title, string $active = ''): void {
     form.frm { grid-template-columns:1fr 1fr; }
   }
 </style>
+<?php
+}
+
+/** رأس بوابة العضو: نفس التنسيق لكن ترويسة موجّهة للعضو (لا نظهر أدوات الموظّفين) */
+function portal_head(string $title): void {
+    $m = current_member();
+    ?><!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title><?=h($title)?> — Xcamp Gym</title>
+<?php page_styles(); ?>
 </head>
 <body>
 <header>
   <span class="brand">🏋️ Xcamp Gym</span>
-  <?php if ($u): ?>
-  <button class="nav-toggle" type="button" aria-label="القائمة">☰</button>
-  <nav>
-    <?php if (is_manager()): ?><a href="index.php" class="<?= $active==='dash' ? 'active' : '' ?>">لوحة الإدارة</a><?php endif; ?>
-    <a href="captains.php" class="<?= $active==='captains' ? 'active' : '' ?>">واجهة الكباتن</a>
-    <a href="crm.php" class="<?= $active==='crm' ? 'active' : '' ?>">CRM</a>
-    <a href="retention.php" class="<?= $active==='retention' ? 'active' : '' ?>">الاحتفاظ</a>
-    <a href="revenue.php" class="<?= $active==='revenue' ? 'active' : '' ?>">الإيرادات</a>
-    <a href="calendar.php" class="<?= $active==='calendar' ? 'active' : '' ?>">التقويم</a>
-    <a href="templates.php" class="<?= $active==='templates' ? 'active' : '' ?>">التمارين والقوالب</a>
-  </nav>
-  <span class="sub">
-    👤 <?=h($u['name'])?> (<?=h($u['role'])?>)
-    · <a href="account.php" style="color:#93c5fd">حسابي</a>
-    · <a href="logout.php">خروج</a>
-    · <span style="color:#475569">قاعدة: <?=h($db)?></span>
+  <span class="sub" style="margin-inline-start:auto">
+    👤 <?=h($m['name'] ?? '')?> · <a href="member_logout.php">خروج</a>
   </span>
-  <?php endif; ?>
 </header>
 <main>
 <?php

--- a/xcamp-gym-sql/dashboard/login.php
+++ b/xcamp-gym-sql/dashboard/login.php
@@ -90,6 +90,7 @@ page_head('تسجيل الدخول');
       مدير: <code>admin@xcamp.com / admin123</code><br>
       كابتن: <code>coach1@xcamp.com / coach123</code>
     </p>
+    <p class="muted" style="font-size:12px;margin-top:6px">عضو؟ ادخل بوابتك من <a class="link" href="member_login.php">هنا</a>.</p>
   </section>
 </div>
 <?php page_foot();

--- a/xcamp-gym-sql/dashboard/member_login.php
+++ b/xcamp-gym-sql/dashboard/member_login.php
@@ -1,0 +1,77 @@
+<?php
+// =============================================================================
+// Xcamp Gym — دخول العضو لبوابته (bcrypt) مع CSRF وتقييد المحاولات الفاشلة.
+//   يدخل بالهاتف أو البريد + كلمة المرور. منفصل تمامًا عن دخول الموظّفين.
+// =============================================================================
+require __DIR__ . '/db.php';
+
+if (current_member()) { header('Location: portal.php'); exit; }
+
+const MRL_MAX = 5;
+const MRL_WINDOW = 900;
+function mrl_file(): string { return sys_get_temp_dir() . '/xcamp_member_attempts.json'; }
+function mrl_load(): array {
+    $d = @json_decode(@file_get_contents(mrl_file()), true) ?: [];
+    $now = time();
+    foreach ($d as $k => $t) { $d[$k] = array_values(array_filter($t, fn($x) => $now - $x < MRL_WINDOW)); if (!$d[$k]) unset($d[$k]); }
+    return $d;
+}
+function mrl_save(array $d): void { @file_put_contents(mrl_file(), json_encode($d), LOCK_EX); }
+
+$error = null;
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    try {
+        csrf_check();
+        $id   = trim($_POST['identifier'] ?? '');
+        $pass = (string)($_POST['password'] ?? '');
+        $key  = ($_SERVER['REMOTE_ADDR'] ?? '?') . '|' . mb_strtolower($id);
+        $rl = mrl_load();
+        if (count($rl[$key] ?? []) >= MRL_MAX) {
+            $wait = (int)ceil((MRL_WINDOW - (time() - min($rl[$key]))) / 60);
+            throw new RuntimeException("تم تجاوز عدد المحاولات. حاول بعد نحو {$wait} دقيقة.");
+        }
+        $st = db()->prepare("SELECT m.member_id, m.full_name, ma.password_hash, ma.portal_enabled
+                             FROM members m JOIN member_auth ma ON ma.member_id = m.member_id
+                             WHERE m.phone = ? OR m.email = ? LIMIT 1");
+        $st->execute([$id, $id]);
+        $mem = $st->fetch();
+        if (!$mem || !password_verify($pass, $mem['password_hash'])) {
+            $rl[$key][] = time(); mrl_save($rl);
+            $left = MRL_MAX - count($rl[$key]);
+            throw new RuntimeException('بيانات الدخول غير صحيحة.' . ($left > 0 ? " (متبقٍ {$left})" : ''));
+        }
+        if (!$mem['portal_enabled']) throw new RuntimeException('بوابتك غير مُفعّلة — راجع الاستقبال.');
+        unset($rl[$key]); mrl_save($rl);
+        db()->prepare("UPDATE member_auth SET last_login_at = NOW() WHERE member_id = ?")->execute([(int)$mem['member_id']]);
+        session_regenerate_id(true);
+        $_SESSION['member'] = ['member_id' => (int)$mem['member_id'], 'name' => $mem['full_name']];
+        header('Location: portal.php');
+        exit;
+    } catch (PDOException $e) {
+        $error = 'تعذّر الاتصال بقاعدة البيانات: ' . $e->getMessage();
+    } catch (Throwable $e) {
+        $error = $e->getMessage();
+    }
+}
+
+page_head('بوابة العضو');
+?>
+<div style="max-width:380px;margin:6vh auto">
+  <section>
+    <h2 style="text-align:center">🏋️ بوابة العضو</h2>
+    <?php if ($error): ?><div class="err" style="margin:0 0 14px"><?=h($error)?></div><?php endif; ?>
+    <form method="post" data-no-ajax style="display:grid;gap:12px">
+      <?=csrf_field()?>
+      <div><label style="font-size:13px;color:#475569;display:block;margin-bottom:4px">الهاتف أو البريد</label>
+        <input name="identifier" required autofocus style="width:100%;padding:9px 11px;border:1px solid #cbd5e1;border-radius:8px"></div>
+      <div><label style="font-size:13px;color:#475569;display:block;margin-bottom:4px">كلمة المرور</label>
+        <input name="password" type="password" required style="width:100%;padding:9px 11px;border:1px solid #cbd5e1;border-radius:8px"></div>
+      <button type="submit" style="background:#2563eb;color:#fff;border:0;padding:11px;border-radius:8px;font-size:15px;font-weight:600;cursor:pointer">دخول</button>
+    </form>
+    <p class="muted" style="font-size:12px;margin-top:14px;line-height:1.7">
+      دخول الموظّفين من <a class="link" href="login.php">هنا</a>.<br>
+      لتفعيل بوابتك اطلب من الكابتن/الاستقبال تعيين كلمة مرور.
+    </p>
+  </section>
+</div>
+<?php page_foot();

--- a/xcamp-gym-sql/dashboard/member_logout.php
+++ b/xcamp-gym-sql/dashboard/member_logout.php
@@ -1,0 +1,5 @@
+<?php
+// خروج العضو: إنهاء جلسة العضو فقط (لا تمسّ جلسة الموظّف إن وُجدت)
+require __DIR__ . '/db.php';
+unset($_SESSION['member']);
+header('Location: member_login.php');

--- a/xcamp-gym-sql/dashboard/portal.php
+++ b/xcamp-gym-sql/dashboard/portal.php
@@ -1,0 +1,309 @@
+<?php
+// =============================================================================
+// Xcamp Gym — بوابة العضو: يشوف برنامجه/تغذيته/تقدّمه، يسجّل تمارينه والتزامه،
+// يضيف قياساته، ويطلب التجديد. كل شيء مقصور على بيانات العضو نفسه (من الجلسة).
+// =============================================================================
+require __DIR__ . '/db.php';
+$member = require_member();
+$meId   = (int)$member['member_id'];
+
+$error = null;
+try { $pdo = db(); } catch (Throwable $e) { $error = $e->getMessage(); }
+
+// معرّف الكابتن (لإسناد مهمة التجديد)
+$myCoach = null;
+if ($pdo && !$error) {
+    $c = $pdo->prepare("SELECT coach_id FROM members WHERE member_id = ?");
+    $c->execute([$meId]);
+    $myCoach = $c->fetchColumn() ?: null;
+}
+
+if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    try {
+        csrf_check();
+        $act = $_POST['action'] ?? '';
+        if ($act === 'member_log_exercise') {
+            $xid = (int)$_POST['session_exercise_id'];
+            // ملكية صارمة: التمرين لازم يخصّ جلسة في برنامج هذا العضو
+            $own = $pdo->prepare("SELECT se.exercise_id FROM session_exercises se
+                                  JOIN workout_sessions ws ON ws.session_id = se.session_id
+                                  JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                                  WHERE se.session_exercise_id = ? AND wp.member_id = ?");
+            $own->execute([$xid, $meId]);
+            $exId = $own->fetchColumn();
+            if ($exId === false) throw new RuntimeException('غير مسموح.');
+            $load = $_POST['load_kg'] !== '' ? (float)$_POST['load_kg'] : null;
+            if ($load !== null) {   // اكتشاف رقم قياسي (مستثنيًا هذا الصف)
+                $pm = $pdo->prepare("SELECT MAX(se.load_kg) FROM session_exercises se
+                                     JOIN workout_sessions ws ON ws.session_id = se.session_id
+                                     JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                                     WHERE wp.member_id = ? AND se.exercise_id = ? AND se.session_exercise_id <> ?");
+                $pm->execute([$meId, (int)$exId, $xid]);
+                $prev = $pm->fetchColumn();
+                if ($prev !== null && $prev !== false && $load > (float)$prev) {
+                    $exName = $pdo->query("SELECT name FROM exercises WHERE exercise_id = " . (int)$exId)->fetchColumn();
+                    $pdo->prepare("INSERT INTO milestones (member_id, milestone_date, milestone_type, description, reward_status)
+                                   VALUES (?, CURDATE(), 'strength_gain', ?, 'badge')")
+                        ->execute([$meId, "🏆 رقم قياسي جديد في {$exName}: {$load} كجم (السابق: {$prev})"]);
+                }
+            }
+            $pdo->prepare("UPDATE session_exercises SET reps = ?, load_kg = ?, rpe = ?, notes = ? WHERE session_exercise_id = ?")
+                ->execute([
+                    trim($_POST['reps'] ?? '') ?: null, $load,
+                    $_POST['rpe'] !== '' ? (int)$_POST['rpe'] : null,
+                    trim($_POST['notes'] ?? '') ?: null, $xid,
+                ]);
+        } elseif ($act === 'member_log_nutrition') {
+            $ad = in_array($_POST['adherence'] ?? '', ['on_plan','partial','off_plan'], true) ? $_POST['adherence'] : 'on_plan';
+            $pdo->prepare("INSERT INTO nutrition_logs (member_id, log_date, adherence, notes)
+                           VALUES (?,?,?,?)
+                           ON DUPLICATE KEY UPDATE adherence = VALUES(adherence), notes = VALUES(notes)")
+                ->execute([$meId, $_POST['log_date'] ?: date('Y-m-d'), $ad, trim($_POST['notes'] ?? '') ?: null]);
+        } elseif ($act === 'member_add_progress') {
+            $num = fn($k) => $_POST[$k] !== '' ? $_POST[$k] : null;
+            $pdo->prepare("INSERT INTO progress_tracking (member_id, record_date, weight, body_fat, muscle_mass, waist, performance_note)
+                           VALUES (?,?,?,?,?,?,?)")
+                ->execute([$meId, $_POST['record_date'] ?: date('Y-m-d'), $num('weight'), $num('body_fat'),
+                           $num('muscle_mass'), $num('waist'), trim($_POST['performance_note'] ?? '') ?: null]);
+        } elseif ($act === 'member_request_renewal') {
+            $pdo->prepare("INSERT INTO tasks (member_id, coach_id, task_type, priority, status, due_at, notes)
+                           VALUES (?,?,'renewal','high','open', DATE_ADD(NOW(), INTERVAL 3 DAY), 'طلب تجديد من العضو عبر البوابة')")
+                ->execute([$meId, $myCoach]);
+        }
+        header('Location: portal.php?ok=1');
+        exit;
+    } catch (Throwable $e) {
+        $error = 'تعذّر الحفظ: ' . $e->getMessage();
+    }
+}
+
+portal_head('بوابتي');
+if ($error && !$pdo) { db_error_box($error); page_foot(); exit; }
+if ($error) echo '<div class="err">' . h($error) . '</div>';
+if (isset($_GET['ok'])) echo '<div class="flash">تم الحفظ بنجاح ✓</div>';
+
+// ---- بيانات العضو (كلها مقصورة على $meId) ----
+$m = $pdo->prepare("SELECT * FROM members WHERE member_id = ?");
+$m->execute([$meId]); $m = $m->fetch();
+
+$mem = $pdo->prepare("SELECT ms.*, p.plan_name, p.price, p.access_level, DATEDIFF(ms.end_date, CURDATE()) AS days_left
+                      FROM memberships ms JOIN plans p ON p.plan_id = ms.plan_id
+                      WHERE ms.member_id = ? ORDER BY ms.end_date DESC LIMIT 1");
+$mem->execute([$meId]); $mem = $mem->fetch();
+
+$comp = $pdo->prepare("SELECT SUM(ws.completion_status='completed') d, COUNT(*) t
+                       FROM workout_sessions ws JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                       WHERE wp.member_id = ? AND ws.session_date BETWEEN DATE_SUB(CURDATE(), INTERVAL 30 DAY) AND CURDATE()");
+$comp->execute([$meId]); $comp = $comp->fetch();
+$compPct = ($comp && (int)$comp['t']) ? round((int)$comp['d'] / (int)$comp['t'] * 100) : null;
+
+$next = $pdo->prepare("SELECT ws.session_id, ws.session_date, ws.muscle_group FROM workout_sessions ws
+                       JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                       WHERE wp.member_id = ? AND ws.session_date >= CURDATE() AND ws.completion_status = 'planned'
+                       ORDER BY ws.session_date LIMIT 1");
+$next->execute([$meId]); $next = $next->fetch();
+
+// البرنامج النشط + جلساته
+$plan = $pdo->prepare("SELECT * FROM workout_plans WHERE member_id = ? AND status = 'active' ORDER BY start_date DESC, workout_plan_id DESC LIMIT 1");
+$plan->execute([$meId]); $plan = $plan->fetch();
+$sessions = [];
+if ($plan) {
+    $ss = $pdo->prepare("SELECT ws.*, (SELECT COUNT(*) FROM session_exercises se WHERE se.session_id = ws.session_id) ex_cnt
+                         FROM workout_sessions ws WHERE ws.workout_plan_id = ? ORDER BY ws.session_date DESC LIMIT 20");
+    $ss->execute([$plan['workout_plan_id']]);
+    $sessions = $ss->fetchAll();
+}
+// جلسة مفتوحة للتسجيل (بتأكيد الملكية)
+$openSid = (int)($_GET['sid'] ?? 0);
+$openSession = null; $openExs = [];
+if ($openSid) {
+    $chk = $pdo->prepare("SELECT ws.session_id, ws.session_date, ws.muscle_group, ws.completion_status
+                          FROM workout_sessions ws JOIN workout_plans wp ON wp.workout_plan_id = ws.workout_plan_id
+                          WHERE ws.session_id = ? AND wp.member_id = ?");
+    $chk->execute([$openSid, $meId]);
+    $openSession = $chk->fetch();
+    if ($openSession) {
+        $ex = $pdo->prepare("SELECT se.*, e.name ex_name, e.muscle_group ex_group FROM session_exercises se
+                             JOIN exercises e ON e.exercise_id = se.exercise_id WHERE se.session_id = ? ORDER BY se.sort_order");
+        $ex->execute([$openSid]); $openExs = $ex->fetchAll();
+    }
+}
+
+// التغذية النشطة + سجلّ الالتزام
+$nutri = $pdo->prepare("SELECT * FROM nutrition_plans WHERE member_id = ? AND status = 'active' ORDER BY nutrition_plan_id DESC LIMIT 1");
+$nutri->execute([$meId]); $nutri = $nutri->fetch();
+$nlogs = $pdo->prepare("SELECT * FROM nutrition_logs WHERE member_id = ? ORDER BY log_date DESC LIMIT 10");
+$nlogs->execute([$meId]); $nlogs = $nlogs->fetchAll();
+$nComp = nutrition_compliance($pdo->query("SELECT adherence FROM nutrition_logs WHERE member_id = $meId AND log_date >= DATE_SUB(CURDATE(), INTERVAL 14 DAY)")->fetchAll());
+
+// التقدّم
+$prog = $pdo->prepare("SELECT * FROM progress_tracking WHERE member_id = ? ORDER BY record_date");
+$prog->execute([$meId]); $prog = $prog->fetchAll();
+// إنجازات
+$mile = $pdo->prepare("SELECT * FROM milestones WHERE member_id = ? ORDER BY milestone_date DESC, milestone_id DESC LIMIT 8");
+$mile->execute([$meId]); $mile = $mile->fetchAll();
+
+$stColor = ['planned'=>'#2563eb','completed'=>'#16a34a','partial'=>'#f59e0b','missed'=>'#dc2626'];
+$payColor = ['paid'=>'#16a34a','partial'=>'#f59e0b','unpaid'=>'#dc2626','failed'=>'#dc2626','refunded'=>'#6b7280'];
+?>
+<div style="margin-bottom:6px"><h2 style="margin:0">👋 أهلًا <?=h($m['full_name'])?></h2></div>
+
+<nav class="tabbar" aria-label="أقسام بوابتي">
+  <button type="button" data-tabtarget="over">🏠 نظرة عامة</button>
+  <button type="button" data-tabtarget="prog">🏋️ برنامجي</button>
+  <button type="button" data-tabtarget="nutr">🥗 تغذيتي</button>
+  <button type="button" data-tabtarget="track">📈 تقدّمي</button>
+  <button type="button" data-tabtarget="sub">🎫 اشتراكي</button>
+</nav>
+
+<!-- ===== نظرة عامة ===== -->
+<section data-tab="over">
+  <h2>🏠 نظرة عامة</h2>
+  <div class="kpis">
+    <div class="card" style="--c:#2563eb"><div class="n" style="color:#2563eb;font-size:22px"><?= $compPct===null ? '—' : $compPct.'%' ?></div><div class="l">التزام التمرين (٣٠ يومًا)</div></div>
+    <div class="card" style="--c:<?=$nComp['color']?>"><div class="n" style="color:<?=$nComp['color']?>;font-size:22px"><?= $nComp['pct']===null ? '—' : $nComp['pct'].'%' ?></div><div class="l">التزام التغذية (١٤ يومًا)</div></div>
+    <div class="card" style="--c:#16a34a"><div class="n" style="color:#16a34a;font-size:22px"><?= $prog ? h(end($prog)['weight']).' كجم' : '—' ?></div><div class="l">آخر وزن</div></div>
+    <div class="card" style="--c:#f59e0b"><div class="n" style="color:#f59e0b;font-size:22px"><?= $mem && $mem['days_left']!==null ? (int)$mem['days_left'].' يوم' : '—' ?></div><div class="l">متبقٍّ على الاشتراك</div></div>
+  </div>
+  <?php if ($next): ?>
+    <div style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:10px;padding:12px 16px;margin-top:6px">
+      ⏭️ جلستك القادمة: <strong><?=h($next['session_date'])?></strong> — <?=h($next['muscle_group'] ?? 'تمرين')?>
+      · <a class="link" href="portal.php?sid=<?=(int)$next['session_id']?>#prog">افتحها وسجّل أداءك ←</a>
+    </div>
+  <?php endif; ?>
+  <?php if ($mile): ?>
+    <h3>🏆 إنجازاتك</h3>
+    <div style="display:flex;gap:8px;flex-wrap:wrap">
+      <?php foreach ($mile as $ml): ?>
+        <span style="background:#fef9c3;color:#854d0e;border:1px solid #fde68a;border-radius:999px;padding:5px 12px;font-size:12px"><?=h($ml['description'])?></span>
+      <?php endforeach; ?>
+    </div>
+  <?php endif; ?>
+</section>
+
+<!-- ===== برنامجي ===== -->
+<section data-tab="prog">
+  <h2>🏋️ برنامجي</h2>
+  <?php if (!$plan): ?><div class="empty">لا يوجد برنامج نشط بعد — سيُسنده كابتنك قريبًا.</div>
+  <?php elseif ($openSession): ?>
+    <div class="crumb"><a class="link" href="portal.php#prog">→ كل الجلسات</a> / <strong>جلسة <?=h($openSession['session_date'])?></strong></div>
+    <div style="display:flex;align-items:center;gap:10px;flex-wrap:wrap;margin-bottom:10px">
+      <strong style="font-size:16px">▶️ <?=h($openSession['muscle_group'] ?? 'تمرين')?></strong>
+      <span class="badge" style="background:<?=$stColor[$openSession['completion_status']] ?? '#6b7280'?>"><?=h($openSession['completion_status'])?></span>
+    </div>
+    <?php if (!$openExs): ?><div class="empty">لا توجد تمارين في هذه الجلسة.</div><?php endif; ?>
+    <?php foreach ($openExs as $i => $x): ?>
+      <div style="border:1px solid #eef2f7;border-radius:10px;padding:12px;margin-bottom:10px">
+        <strong style="font-size:15px"><?=($i+1)?>. <?=h($x['ex_name'])?></strong>
+        <span class="muted" style="font-size:12px">· <?=h($x['ex_group'])?><?= $x['sets'] ? ' · '.h($x['sets']).' مجموعات' : '' ?></span>
+        <form class="frm" method="post" style="margin-top:8px"><?=csrf_field()?>
+          <input type="hidden" name="action" value="member_log_exercise">
+          <input type="hidden" name="session_exercise_id" value="<?=$x['session_exercise_id']?>">
+          <div><label>تكرارات</label><input name="reps" value="<?=h($x['reps'])?>"></div>
+          <div><label>الحمل الفعلي (كجم)</label><input type="number" step="0.5" name="load_kg" value="<?=h($x['load_kg'])?>" style="border:2px solid #2563eb;font-weight:700"></div>
+          <div><label>RPE (الجهد ١-١٠)</label><input type="number" name="rpe" min="1" max="10" value="<?=h($x['rpe'])?>"></div>
+          <div><label>ملاحظة</label><input name="notes" value="<?=h($x['notes'])?>"></div>
+          <div><button type="submit">💾 حفظ</button></div>
+        </form>
+      </div>
+    <?php endforeach; ?>
+    <p class="muted" style="font-size:12px">تسجيل حمل أعلى من رقمك السابق يمنحك إنجاز 🏆 تلقائيًا.</p>
+  <?php else: ?>
+    <div class="muted" style="font-size:13px;margin-bottom:10px"><?=h($plan['goal_type'])?> · <?=h($plan['phase'])?> · <?=h($plan['start_date'])?> ← <?=h($plan['end_date'] ?? '')?></div>
+    <table>
+      <tr><th>التاريخ</th><th>المجموعة</th><th>تمارين</th><th>الحالة</th><th></th></tr>
+      <?php foreach ($sessions as $s): ?>
+        <tr>
+          <td><?=h($s['session_date'])?></td><td><?=h($s['muscle_group'] ?? '—')?></td><td><?=h($s['ex_cnt'])?></td>
+          <td><span class="badge" style="background:<?=$stColor[$s['completion_status']] ?? '#6b7280'?>"><?=h($s['completion_status'])?></span></td>
+          <td><a class="link" href="portal.php?sid=<?=(int)$s['session_id']?>#prog">سجّل أداءك ←</a></td>
+        </tr>
+      <?php endforeach; ?>
+    </table>
+  <?php endif; ?>
+</section>
+
+<!-- ===== تغذيتي ===== -->
+<section data-tab="nutr">
+  <h2>🥗 تغذيتي</h2>
+  <?php if (!$nutri): ?><div class="empty">لا توجد خطة تغذية نشطة بعد.</div>
+  <?php else: ?>
+    <div class="kpis" style="margin-bottom:8px">
+      <div class="card" style="--c:#2563eb"><div class="n" style="font-size:22px"><?=h($nutri['calories'] ?? '—')?></div><div class="l">سعرات/يوم</div></div>
+      <div class="card" style="--c:#16a34a"><div class="n" style="font-size:22px"><?=h($nutri['protein_g'] ?? '—')?></div><div class="l">بروتين (g)</div></div>
+      <div class="card" style="--c:#f59e0b"><div class="n" style="font-size:22px"><?=h($nutri['carbs_g'] ?? '—')?></div><div class="l">كارب (g)</div></div>
+      <div class="card" style="--c:#dc2626"><div class="n" style="font-size:22px"><?=h($nutri['fat_g'] ?? '—')?></div><div class="l">دهون (g)</div></div>
+    </div>
+    <?php if ($nutri['meal_timing']): ?><p class="muted" style="font-size:12px">🍽️ <?=h($nutri['meal_timing'])?></p><?php endif; ?>
+  <?php endif; ?>
+  <h3>➕ سجّل التزامك اليوم</h3>
+  <form class="frm" method="post"><?=csrf_field()?>
+    <input type="hidden" name="action" value="member_log_nutrition">
+    <div><label>التاريخ</label><input type="date" name="log_date" value="<?=date('Y-m-d')?>" required></div>
+    <div><label>الالتزام</label><select name="adherence"><option value="on_plan">ملتزم</option><option value="partial">جزئي</option><option value="off_plan">خارج الخطة</option></select></div>
+    <div style="grid-column:1/-1"><label>ملاحظة</label><input name="notes"></div>
+    <div><button type="submit">حفظ</button></div>
+  </form>
+  <?php if ($nlogs): ?>
+    <h3>آخر أيامك (<?= $nComp['pct']!==null ? 'التزام '.$nComp['pct'].'%' : '' ?>)</h3>
+    <table><tr><th>التاريخ</th><th>الالتزام</th><th>ملاحظة</th></tr>
+      <?php $al=['on_plan'=>['ملتزم','#16a34a'],'partial'=>['جزئي','#f59e0b'],'off_plan'=>['خارج الخطة','#dc2626']];
+      foreach ($nlogs as $lg): [$l,$c]=$al[$lg['adherence']]; ?>
+        <tr><td><?=h($lg['log_date'])?></td><td><span class="badge" style="background:<?=$c?>"><?=$l?></span></td><td class="muted"><?=h($lg['notes'])?></td></tr>
+      <?php endforeach; ?>
+    </table>
+  <?php endif; ?>
+</section>
+
+<!-- ===== تقدّمي ===== -->
+<section data-tab="track">
+  <h2>📈 تقدّمي</h2>
+  <?php if ($prog): ?>
+    <?php
+    $wS = ['label'=>'الوزن (kg)','color'=>'#2563eb','points'=>array_map(fn($r)=>[$r['record_date'],$r['weight']],$prog)];
+    $mS = ['label'=>'الكتلة العضلية (kg)','color'=>'#16a34a','points'=>array_map(fn($r)=>[$r['record_date'],$r['muscle_mass']],$prog)];
+    $fS = ['label'=>'الدهون (%)','color'=>'#f59e0b','points'=>array_map(fn($r)=>[$r['record_date'],$r['body_fat']],$prog)];
+    ?>
+    <div class="grid2">
+      <div><strong style="font-size:13px;color:#334155">الوزن والكتلة</strong><?=line_chart([$wS,$mS])?></div>
+      <div><strong style="font-size:13px;color:#334155">نسبة الدهون</strong><?=line_chart([$fS])?></div>
+    </div>
+  <?php else: ?><div class="empty">لا توجد قياسات بعد — أضِف أول قياس بالأسفل.</div><?php endif; ?>
+  <h3>➕ أضِف قياسًا</h3>
+  <form class="frm" method="post"><?=csrf_field()?>
+    <input type="hidden" name="action" value="member_add_progress">
+    <div><label>التاريخ</label><input type="date" name="record_date" value="<?=date('Y-m-d')?>" required></div>
+    <div><label>الوزن (kg)</label><input type="number" step="0.1" name="weight"></div>
+    <div><label>نسبة الدهون (%)</label><input type="number" step="0.1" name="body_fat"></div>
+    <div><label>الكتلة العضلية (kg)</label><input type="number" step="0.1" name="muscle_mass"></div>
+    <div><label>الخصر (cm)</label><input type="number" step="0.1" name="waist"></div>
+    <div style="grid-column:1/-1"><label>ملاحظة</label><input name="performance_note"></div>
+    <div><button type="submit">حفظ القياس</button></div>
+  </form>
+</section>
+
+<!-- ===== اشتراكي ===== -->
+<section data-tab="sub">
+  <h2>🎫 اشتراكي</h2>
+  <?php if (!$mem): ?><div class="empty">لا يوجد اشتراك مسجّل.</div>
+  <?php else:
+    $dl = (int)$mem['days_left']; ?>
+    <table>
+      <tr><td>الخطة</td><td><strong><?=h($mem['plan_name'])?></strong> (<?=h($mem['access_level'])?>)</td></tr>
+      <tr><td>تبدأ</td><td><?=h($mem['start_date'])?></td></tr>
+      <tr><td>تنتهي</td><td><strong style="color:<?= $dl<0?'#dc2626':($dl<=7?'#f59e0b':'#334155') ?>"><?=h($mem['end_date'])?> (<?= $dl<0 ? 'منتهٍ' : $dl.' يوم' ?>)</strong></td></tr>
+      <tr><td>حالة التجديد</td><td><?=h($mem['renewal_status'])?></td></tr>
+      <tr><td>حالة الدفع</td><td><span style="color:<?=$payColor[$mem['payment_status']] ?? '#64748b'?>;font-weight:600"><?=h($mem['payment_status'])?></span></td></tr>
+    </table>
+    <?php if ($mem['renewal_status'] !== 'renewed'): ?>
+      <form method="post" style="margin-top:12px" onsubmit="return confirm('إرسال طلب تجديد لفريق الجيم؟')"><?=csrf_field()?>
+        <input type="hidden" name="action" value="member_request_renewal">
+        <button type="submit" style="background:#16a34a;color:#fff;border:0;padding:10px 18px;border-radius:8px;font-size:14px;font-weight:600;cursor:pointer">🔄 اطلب تجديد اشتراكي</button>
+      </form>
+      <p class="muted" style="font-size:12px;margin-top:8px">سيصل طلبك لكابتنك/الاستقبال كمهمة تجديد.</p>
+    <?php else: ?>
+      <div style="background:#dcfce7;color:#166534;padding:10px 14px;border-radius:8px;margin-top:12px">✅ اشتراكك مُجدَّد. استمتع بتمرينك!</div>
+    <?php endif; ?>
+  <?php endif; ?>
+</section>
+<?php page_foot();

--- a/xcamp-gym-sql/dashboard/setup_member_logins.sql
+++ b/xcamp-gym-sql/dashboard/setup_member_logins.sql
@@ -1,0 +1,10 @@
+-- =============================================================================
+-- xcamp-gym-sql / dashboard : setup_member_logins.sql
+-- يفعّل بوابة العضو لأعضاء البذرة بكلمة مرور تجريبية موحّدة (member123).
+-- شغّله بعد تحميل القاعدة:  sudo mysql xcamp_gym < setup_member_logins.sql
+-- الدخول: بالهاتف أو البريد + member123  (مثال: 01111111101 / member123)
+-- =============================================================================
+USE xcamp_gym;
+INSERT INTO member_auth (member_id, password_hash, portal_enabled)
+SELECT member_id, '$2y$12$L3jxt2TWBjZuV/cq1g3C4ueYq0bCMNj7vBQJyVgLJ75hWRdLYKv.2', 1 FROM members
+ON DUPLICATE KEY UPDATE password_hash = VALUES(password_hash), portal_enabled = 1;

--- a/xcamp-gym-sql/deploy.sh
+++ b/xcamp-gym-sql/deploy.sh
@@ -22,6 +22,7 @@ FILES=(
   "06_seed_data.sql"
   "08_workout_v2.sql"
   "09_nutrition_v2.sql"
+  "10_member_portal.sql"
   "07_test_queries.sql"
 )
 

--- a/xcamp-gym-sql/run_all.sql
+++ b/xcamp-gym-sql/run_all.sql
@@ -12,6 +12,7 @@ SOURCE sql/06_seed_data.sql;
 SET @seeding = NULL;
 SOURCE sql/08_workout_v2.sql;
 SOURCE sql/09_nutrition_v2.sql;
+SOURCE sql/10_member_portal.sql;
 SOURCE sql/07_test_queries.sql;
 
 -- Restore the session state saved in 00_init.sql (valid here because run_all

--- a/xcamp-gym-sql/sql/10_member_portal.sql
+++ b/xcamp-gym-sql/sql/10_member_portal.sql
@@ -1,0 +1,25 @@
+-- =============================================================================
+-- xcamp-gym-sql : 10_member_portal.sql  (ترقية إضافية — لا تمسّ المخطط الأصلي)
+-- -----------------------------------------------------------------------------
+-- بوابة العضو: مصادقة العضو للدخول بنفسه (منفصلة عن جدول users للموظّفين).
+--   member_auth   بيانات دخول العضو (bcrypt) + تفعيل البوابة + آخر دخول
+--
+-- الملف قابل لإعادة التشغيل: CREATE IF NOT EXISTS.
+-- =============================================================================
+
+USE xcamp_gym;
+
+-- يضمن قراءة النصوص العربية في هذا الملف بشكل صحيح أيًّا كان ترميز العميل
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS member_auth (
+    member_id       BIGINT UNSIGNED NOT NULL,
+    password_hash   VARCHAR(255)    NOT NULL,
+    portal_enabled  TINYINT(1)      NOT NULL DEFAULT 1,
+    last_login_at   DATETIME        NULL,
+    created_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at      TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (member_id),
+    CONSTRAINT fk_member_auth_member FOREIGN KEY (member_id)
+        REFERENCES members (member_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary

The first **member-facing** surface — everything before this was staff-only. Members log into their own portal (separate from staff) and can only ever see or touch **their own data** (`member_id` comes from the session, never from input).

## Auth (additive — no core-schema change)

- **`sql/10_member_portal.sql`** — `member_auth` table (bcrypt, `portal_enabled`, `last_login_at`, FK to `members`). Wired into `run_all.sql` and `deploy.sh`.
- **`db.php`** — `current_member()` / `require_member()` (distinct from staff auth); the layout refactored so `page_head` and a new member-facing `portal_head()` share a `page_styles()` block.
- **`member_login.php`** (login by phone or email + password, CSRF + rate-limited), **`member_logout.php`**. **`setup_member_logins.sql`** seeds demo passwords for testing.
- **`captains.php`** — staff action `set_member_portal` to enable/reset a member's portal password; reciprocal links between the staff and member login pages.

## `portal.php` (Phase-4 tabs, all own-member scoped)

- **🏠 نظرة عامة** — workout + nutrition compliance, latest weight, days left on the membership, next session, achievements.
- **🏋️ برنامجي** — the active plan's sessions; open one and **log actual reps/load/RPE** per exercise — beating a previous max mints a **🏆 strength_gain milestone**.
- **🥗 تغذيتي** — active plan macros/meal timing + **daily adherence logging**.
- **📈 تقدّمي** — weight/muscle/fat charts + **add a new measurement**.
- **🎫 اشتراكي** — membership details + **"request renewal"** (opens a renewal task for staff).

## Verification (live MariaDB 10.11 + PHP 8.4)

- Member login **(302)**; portal renders own data; **self-logging an exercise persists and fires the PR milestone** on a new max (Back Squat 300 → strength_gain); nutrition / progress / renewal-task actions all save.
- **Security:** a member hitting a staff page is redirected to `login.php`; **logging another member's exercise is denied** and that row is untouched (Hassan's load stayed 120 when member 1 tried 999).
- Fresh **`run_all.sql`** creates `member_auth`; `php -l` clean on all files; screenshots (desktop overview + mobile session logging) captured.

## Note

This PR includes a migration — after merge, run once with `./update.sh --deploy` to create `member_auth`, then `setup_member_logins.sql` (or use the staff "🔑 بوابة العضو" action) to give members passwords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK

---
_Generated by [Claude Code](https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK)_