### PR TITLE
QR check-in: pure-PHP QR generator, kiosk scanner, member code, auto-attendance

### DIFF
--- a/xcamp-gym-sql/dashboard/checkin.php
+++ b/xcamp-gym-sql/dashboard/checkin.php
@@ -1,0 +1,108 @@
+<?php
+// =============================================================================
+// Xcamp Gym — الحضور بالـ QR (شاشة الاستقبال/الكشك): امسح رمز العضو أو اكتب الهاتف
+// → تسجيل حضور اليوم في daily_attendance (تعمل أتمتة المتابعة) + بطاقة تأكيد.
+// =============================================================================
+require __DIR__ . '/db.php';
+$me = require_login();
+
+$error = null; $result = null;
+try { $pdo = db(); } catch (Throwable $e) { $error = $e->getMessage(); }
+
+if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    try {
+        csrf_check();
+        $code = trim($_POST['code'] ?? '');
+        if ($code === '') throw new RuntimeException('امسح الرمز أو اكتب الهاتف.');
+        // ابحث بالرمز (QR) أولًا، ثم بالهاتف أو رقم العضو
+        $m = $pdo->prepare("SELECT m.member_id, m.full_name, m.status, m.coach_id
+                            FROM member_qr q JOIN members m ON m.member_id = q.member_id WHERE q.token = ?");
+        $m->execute([$code]); $mem = $m->fetch();
+        if (!$mem) {
+            $m = $pdo->prepare("SELECT member_id, full_name, status, coach_id FROM members WHERE phone = ? OR member_id = ?");
+            $m->execute([$code, ctype_digit($code) ? (int)$code : 0]); $mem = $m->fetch();
+        }
+        if (!$mem) throw new RuntimeException('لم يُعثر على عضو مطابق للرمز/الهاتف.');
+        $mid = (int)$mem['member_id'];
+        // اشتراك العضو (لتنبيه الانتهاء)
+        $ms = $pdo->prepare("SELECT ms.end_date, ms.payment_status, DATEDIFF(ms.end_date, CURDATE()) days_left
+                             FROM memberships ms WHERE ms.member_id = ? ORDER BY ms.end_date DESC LIMIT 1");
+        $ms->execute([$mid]); $ms = $ms->fetch();
+        // سجّل حضور اليوم إن لم يكن مسجّلًا (يشغّل sp_handle_attendance_event عبر الـ trigger)
+        $dup = $pdo->prepare("SELECT check_in_time FROM daily_attendance WHERE member_id = ? AND attendance_date = CURDATE()");
+        $dup->execute([$mid]); $already = $dup->fetchColumn();
+        if ($already === false) {
+            $pdo->prepare("INSERT INTO daily_attendance (member_id, coach_id, attendance_date, check_in_time, attended, session_type, notes)
+                           VALUES (?,?,CURDATE(),CURTIME(),1,'training','دخول عبر QR')")
+                ->execute([$mid, (int)$mem['coach_id'] ?: null]);
+            $checkTime = date('H:i');
+        } else {
+            $checkTime = substr((string)$already, 0, 5);
+        }
+        $result = ['name' => $mem['full_name'], 'status' => $mem['status'], 'time' => $checkTime,
+                   'repeat' => $already !== false, 'ms' => $ms];
+    } catch (Throwable $e) {
+        $error = $e->getMessage();
+    }
+}
+
+// آخر عمليات الدخول اليوم
+$today = [];
+if ($pdo && !$error) {
+    $today = $pdo->query("SELECT da.check_in_time, m.full_name FROM daily_attendance da
+                          JOIN members m ON m.member_id = da.member_id
+                          WHERE da.attendance_date = CURDATE() AND da.attended = 1
+                          ORDER BY da.check_in_time DESC LIMIT 12")->fetchAll();
+}
+
+page_head('الحضور (QR)', 'checkin');
+if ($error && !$pdo) { db_error_box($error); page_foot(); exit; }
+$stColor = ['active'=>'#16a34a','new'=>'#0891b2','onboarding'=>'#0891b2','at_risk'=>'#f59e0b','corrective'=>'#f59e0b','paused'=>'#6b7280','expired'=>'#dc2626'];
+?>
+<section>
+  <h2>📷 تسجيل الحضور</h2>
+  <?php if ($error): ?><div class="err" style="margin:0 0 14px"><?=h($error)?></div><?php endif; ?>
+  <?php if ($result):
+    $ms = $result['ms']; $expired = $ms && $ms['days_left'] !== null && (int)$ms['days_left'] < 0;
+    $soon = $ms && $ms['days_left'] !== null && (int)$ms['days_left'] >= 0 && (int)$ms['days_left'] <= 7;
+    $bg = $expired ? '#fef2f2' : '#f0fdf4'; $bd = $expired ? '#fecaca' : '#bbf7d0'; ?>
+    <div style="background:<?=$bg?>;border:2px solid <?=$bd?>;border-radius:14px;padding:20px;margin-bottom:16px;text-align:center">
+      <div style="font-size:44px;line-height:1">✅</div>
+      <div style="font-size:22px;font-weight:800;margin-top:6px"><?= $result['repeat'] ? 'مسجّل مسبقًا' : 'أهلًا' ?> <?=h($result['name'])?></div>
+      <div style="margin-top:6px">
+        <span class="badge" style="background:<?=$stColor[$result['status']] ?? '#6b7280'?>"><?=h($result['status'])?></span>
+        <span class="muted" style="font-size:13px">· دخول <?=h($result['time'])?></span>
+      </div>
+      <?php if ($expired): ?>
+        <div style="margin-top:10px;color:#991b1b;font-weight:700">⚠️ الاشتراك منتهٍ منذ <?=abs((int)$ms['days_left'])?> يوم — يرجى التجديد.</div>
+      <?php elseif ($soon): ?>
+        <div style="margin-top:10px;color:#92400e;font-weight:700">⏰ يتبقّى <?=(int)$ms['days_left']?> يوم على انتهاء الاشتراك.</div>
+      <?php elseif ($ms && ($ms['payment_status'] ?? '') !== 'paid'): ?>
+        <div style="margin-top:10px;color:#92400e">💳 حالة الدفع: <?=h($ms['payment_status'])?></div>
+      <?php endif; ?>
+    </div>
+  <?php endif; ?>
+  <form method="post" data-no-ajax style="display:flex;gap:10px;flex-wrap:wrap;align-items:end"><?=csrf_field()?>
+    <div style="flex:1;min-width:220px">
+      <label style="font-size:13px;color:#475569;display:block;margin-bottom:4px">امسح رمز العضو (QR) أو اكتب الهاتف</label>
+      <input name="code" autofocus autocomplete="off" placeholder="امسح الكود أو اكتب الهاتف…"
+             style="width:100%;padding:14px;border:2px solid #2563eb;border-radius:10px;font-size:18px">
+    </div>
+    <button type="submit" style="background:#16a34a;color:#fff;border:0;padding:14px 22px;border-radius:10px;font-size:16px;font-weight:700;cursor:pointer">تسجيل</button>
+  </form>
+  <p class="muted" style="font-size:12px;margin:10px 0 0">قارئ الـ QR/الباركود يكتب الرمز في الخانة تلقائيًا ويُرسل — الحقل يبقى مركّزًا لمسح متتالٍ. العضو يجد رمزه في بوابته.</p>
+</section>
+
+<section>
+  <h2>🕒 دخول اليوم (<?=count($today)?>)</h2>
+  <?php if (!$today): ?><div class="empty">لا حضور مسجّل اليوم بعد.</div><?php else: ?>
+  <table><tr><th>الوقت</th><th>العضو</th></tr>
+    <?php foreach ($today as $t): ?><tr><td><?=h(substr((string)$t['check_in_time'],0,5))?></td><td><?=h($t['full_name'])?></td></tr><?php endforeach; ?>
+  </table>
+  <?php endif; ?>
+</section>
+<script>
+// أبقِ حقل المسح مركّزًا دائمًا لتجربة كشك سلسة
+(function(){ var i=document.querySelector('input[name=code]'); if(i){ i.focus(); i.select && i.select(); } })();
+</script>
+<?php page_foot();

--- a/xcamp-gym-sql/dashboard/db.php
+++ b/xcamp-gym-sql/dashboard/db.php
@@ -68,6 +68,20 @@ function is_manager(): bool {
     return $u && in_array($u['role'], ['admin','manager','reception'], true);
 }
 
+/** رمز دخول العضو للـ QR — يُنشأ عند أول طلب ويُخزَّن (16 حرفًا، يتجنّب حدود سعة QR) */
+function member_qr_token(PDO $pdo, int $memberId): string {
+    $q = $pdo->prepare("SELECT token FROM member_qr WHERE member_id = ?");
+    $q->execute([$memberId]);
+    $tok = $q->fetchColumn();
+    if ($tok !== false) return $tok;
+    $tok = 'XCG-' . bin2hex(random_bytes(6));   // 4 + 12 = 16 حرفًا
+    $pdo->prepare("INSERT INTO member_qr (member_id, token) VALUES (?,?)
+                   ON DUPLICATE KEY UPDATE token = token")->execute([$memberId, $tok]);
+    // في حال تسابق نادر أعِد القراءة
+    $q->execute([$memberId]);
+    return $q->fetchColumn() ?: $tok;
+}
+
 // ---- مصادقة العضو (بوابة العضو — منفصلة عن الموظّفين) ----
 function current_member(): ?array { return $_SESSION['member'] ?? null; }
 function require_member(): array {
@@ -110,6 +124,7 @@ function page_head(string $title, string $active = ''): void {
   <nav>
     <?php if (is_manager()): ?><a href="index.php" class="<?= $active==='dash' ? 'active' : '' ?>">لوحة الإدارة</a><?php endif; ?>
     <a href="captains.php" class="<?= $active==='captains' ? 'active' : '' ?>">واجهة الكباتن</a>
+    <a href="checkin.php" class="<?= $active==='checkin' ? 'active' : '' ?>">الحضور (QR)</a>
     <a href="crm.php" class="<?= $active==='crm' ? 'active' : '' ?>">CRM</a>
     <a href="retention.php" class="<?= $active==='retention' ? 'active' : '' ?>">الاحتفاظ</a>
     <a href="revenue.php" class="<?= $active==='revenue' ? 'active' : '' ?>">الإيرادات</a>

--- a/xcamp-gym-sql/dashboard/portal.php
+++ b/xcamp-gym-sql/dashboard/portal.php
@@ -4,6 +4,7 @@
 // يضيف قياساته، ويطلب التجديد. كل شيء مقصور على بيانات العضو نفسه (من الجلسة).
 // =============================================================================
 require __DIR__ . '/db.php';
+require_once __DIR__ . '/qr.php';
 $member = require_member();
 $meId   = (int)$member['member_id'];
 
@@ -171,6 +172,11 @@ $payColor = ['paid'=>'#16a34a','partial'=>'#f59e0b','unpaid'=>'#dc2626','failed'
       · <a class="link" href="portal.php?sid=<?=(int)$next['session_id']?>#prog">افتحها وسجّل أداءك ←</a>
     </div>
   <?php endif; ?>
+  <div style="border:1px solid #eef2f7;border-radius:12px;padding:16px;margin-top:8px;text-align:center;max-width:280px">
+    <strong style="font-size:14px;color:#334155">🎫 رمز دخولك</strong>
+    <div style="margin:10px auto;width:180px"><?= qr_svg(member_qr_token($pdo, $meId), 5) ?></div>
+    <p class="muted" style="font-size:12px;margin:0">اعرض هذا الرمز عند الاستقبال لتسجيل حضورك.</p>
+  </div>
   <?php if ($mile): ?>
     <h3>🏆 إنجازاتك</h3>
     <div style="display:flex;gap:8px;flex-wrap:wrap">

--- a/xcamp-gym-sql/dashboard/qr.php
+++ b/xcamp-gym-sql/dashboard/qr.php
@@ -1,0 +1,247 @@
+<?php
+// =============================================================================
+// Xcamp Gym — مولّد QR نقي بالـ PHP (بدون مكتبات/إنترنت). وضع البايت، تصحيح L،
+// الإصدارات 1..4 (كتلة واحدة). يُنتج مصفوفة الوحدات ثم SVG قابل للمسح.
+// مُتحقَّق منه بمطابقة مصفوفته لمكتبة segno وفكّه بـ OpenCV.
+// =============================================================================
+
+/** جداول GF(256) بالمولّد البدائي 0x11d */
+function qr_gf_tables(): array {
+    static $exp = null, $log = null;
+    if ($exp !== null) return [$exp, $log];
+    $exp = array_fill(0, 512, 0); $log = array_fill(0, 256, 0);
+    $x = 1;
+    for ($i = 0; $i < 255; $i++) {
+        $exp[$i] = $x; $log[$x] = $i;
+        $x <<= 1;
+        if ($x & 0x100) $x ^= 0x11d;
+    }
+    for ($i = 255; $i < 512; $i++) $exp[$i] = $exp[$i - 255];
+    return [$exp, $log];
+}
+
+/** ضرب في GF(256) */
+function qr_gf_mul(int $a, int $b): int {
+    if ($a === 0 || $b === 0) return 0;
+    [$exp, $log] = qr_gf_tables();
+    return $exp[$log[$a] + $log[$b]];
+}
+
+/** مولّد كثيرة حدود تصحيح الأخطاء لعدد codewords */
+function qr_rs_generator(int $n): array {
+    $g = [1];
+    [$exp, $log] = qr_gf_tables();
+    for ($i = 0; $i < $n; $i++) {
+        $ng = array_fill(0, count($g) + 1, 0);
+        foreach ($g as $j => $c) {
+            $ng[$j]     ^= qr_gf_mul($c, 1);
+            $ng[$j + 1] ^= qr_gf_mul($c, $exp[$i]);
+        }
+        $g = $ng;
+    }
+    return $g;
+}
+
+/** حساب codewords تصحيح الأخطاء لبيانات معطاة */
+function qr_rs_encode(array $data, int $ecLen): array {
+    $gen = qr_rs_generator($ecLen);
+    $res = array_fill(0, $ecLen, 0);
+    foreach ($data as $d) {
+        $factor = $d ^ $res[0];
+        array_shift($res); $res[] = 0;
+        if ($factor !== 0) foreach ($gen as $i => $g) if ($i > 0) $res[$i - 1] ^= qr_gf_mul($g, $factor);
+    }
+    return $res;
+}
+
+/**
+ * يبني مصفوفة QR (مصفوفة 2D من 0/1) للبيانات النصّية. يرجّع [matrix, size].
+ * ثابت: وضع البايت، تصحيح L، أصغر إصدار مناسب من 1..4، أفضل قناع حسب الجزاء.
+ */
+function qr_matrix(string $data, ?int $forceMask = null): array {
+    // سعة البايت (تصحيح L) للإصدارات 1..4 + طول codewords تصحيح الأخطاء + إجمالي codewords البيانات
+    $CAP     = [1 => 17, 2 => 32, 3 => 53, 4 => 78];
+    $ECLEN   = [1 => 7,  2 => 10, 3 => 15, 4 => 20];
+    $DATACW  = [1 => 19, 2 => 34, 3 => 55, 4 => 80];
+    $ALIGN   = [1 => [], 2 => [6, 18], 3 => [6, 22], 4 => [6, 26]];
+    $bytes = array_values(unpack('C*', $data));
+    $len = count($bytes);
+    $ver = 0;
+    foreach ($CAP as $v => $cap) if ($len <= $cap) { $ver = $v; break; }
+    if ($ver === 0) throw new RuntimeException('البيانات أطول من طاقة QR (v4-L).');
+
+    // ---- تيار البِتّات: وضع البايت (0100) + العدّ (8 بت) + البيانات ----
+    $bits = '';
+    $bits .= '0100';
+    $bits .= str_pad(decbin($len), 8, '0', STR_PAD_LEFT);
+    foreach ($bytes as $b) $bits .= str_pad(decbin($b), 8, '0', STR_PAD_LEFT);
+    $totalDataBits = $DATACW[$ver] * 8;
+    // منهٍ (حتى 4 أصفار)
+    $bits .= str_repeat('0', min(4, $totalDataBits - strlen($bits)));
+    // حشو لإكمال بايت (مطابق لـ ISO/segno: يضيف 8 - (len%8) دائمًا — بايت صفري عند المحاذاة)
+    $bits .= str_repeat('0', 8 - (strlen($bits) % 8));
+    // بايتات حشو 0xEC 0x11 بالتناوب
+    $pads = [0xEC, 0x11]; $pi = 0;
+    while (strlen($bits) < $totalDataBits) { $bits .= str_pad(decbin($pads[$pi % 2]), 8, '0', STR_PAD_LEFT); $pi++; }
+    $bits = substr($bits, 0, $totalDataBits);   // اقتطاع أي فائض عند امتلاء السعة تمامًا
+    // codewords البيانات
+    $dataCW = [];
+    for ($i = 0; $i < strlen($bits); $i += 8) $dataCW[] = bindec(substr($bits, $i, 8));
+    // تصحيح الأخطاء (كتلة واحدة)
+    $ecCW = qr_rs_encode($dataCW, $ECLEN[$ver]);
+    $allCW = array_merge($dataCW, $ecCW);
+    // بِتّات نهائية (MSB أولًا)
+    $final = '';
+    foreach ($allCW as $cw) $final .= str_pad(decbin($cw), 8, '0', STR_PAD_LEFT);
+
+    $size = 17 + $ver * 4;
+    $m = []; $fn = [];   // m: الوحدات، fn: هل الوحدة وظيفية (لا تُقنَّع)
+    for ($r = 0; $r < $size; $r++) { $m[$r] = array_fill(0, $size, 0); $fn[$r] = array_fill(0, $size, false); }
+
+    $setF = function ($r, $c, $v) use (&$m, &$fn) { $m[$r][$c] = $v; $fn[$r][$c] = true; };
+    // finder + separators
+    $placeFinder = function ($ro, $co) use ($setF, $size) {
+        for ($r = -1; $r <= 7; $r++) for ($c = -1; $c <= 7; $c++) {
+            $rr = $ro + $r; $cc = $co + $c;
+            if ($rr < 0 || $rr >= $size || $cc < 0 || $cc >= $size) continue;
+            $v = ($r >= 0 && $r <= 6 && ($c === 0 || $c === 6)) ||
+                 ($c >= 0 && $c <= 6 && ($r === 0 || $r === 6)) ||
+                 ($r >= 2 && $r <= 4 && $c >= 2 && $c <= 4) ? 1 : 0;
+            $setF($rr, $cc, $v);
+        }
+    };
+    $placeFinder(0, 0); $placeFinder(0, $size - 7); $placeFinder($size - 7, 0);
+    // timing
+    for ($i = 8; $i < $size - 8; $i++) { $setF(6, $i, ($i % 2 === 0) ? 1 : 0); $setF($i, 6, ($i % 2 === 0) ? 1 : 0); }
+    // dark module
+    $setF($size - 8, 8, 1);
+    // alignment
+    $ap = $ALIGN[$ver];
+    foreach ($ap as $ar) foreach ($ap as $ac) {
+        if (($ar <= 8 && $ac <= 8) || ($ar <= 8 && $ac >= $size - 9) || ($ar >= $size - 9 && $ac <= 8)) continue;
+        for ($r = -2; $r <= 2; $r++) for ($c = -2; $c <= 2; $c++)
+            $setF($ar + $r, $ac + $c, (max(abs($r), abs($c)) !== 1) ? 1 : 0);
+    }
+    // احجز مناطق معلومات الصيغة (تُملأ لاحقًا)
+    $reserveFormat = function () use (&$fn, $size) {
+        for ($i = 0; $i <= 8; $i++) { if ($i !== 6) { $fn[8][$i] = true; $fn[$i][8] = true; } }
+        for ($i = 0; $i < 8; $i++) { $fn[8][$size - 1 - $i] = true; $fn[$size - 1 - $i][8] = true; }
+    };
+    $reserveFormat();
+
+    // ---- وضع بِتّات البيانات (زجزاج من أسفل-يمين) ----
+    // الاتجاه يُشتقّ من موضع العمود (لا بالتبديل) حتى لا يختلّ بعد تخطّي عمود التوقيت.
+    // مطابق لخوارزمية ISO/segno: أعمدة بعرض وحدتين، الاتجاه من العمود مع قلبه يسار عمود التوقيت.
+    $idx = 0;
+    for ($right = $size - 1; $right > 0; $right -= 2) {
+        $rr = ($right <= 6) ? $right - 1 : $right;   // تخطّي عمود التوقيت (6)
+        for ($vertical = 0; $vertical < $size; $vertical++) {
+            for ($z = 0; $z < 2; $z++) {
+                $j  = $rr - $z;
+                $up = ((($rr & 2) === 0) !== ($j < 6));   // XOR منطقي (تجنّب أولوية xor في PHP)
+                $i  = $up ? ($size - 1 - $vertical) : $vertical;
+                if ($fn[$i][$j]) continue;
+                $bit = ($idx < strlen($final)) ? (int)$final[$idx] : 0;
+                $m[$i][$j] = $bit; $idx++;
+            }
+        }
+    }
+
+    // ---- اختيار أفضل قناع ----
+    $best = null; $bestPen = PHP_INT_MAX; $bestMask = 0;
+    for ($mask = 0; $mask < 8; $mask++) {
+        if ($forceMask !== null && $mask !== $forceMask) continue;
+        $mm = $m;
+        for ($r = 0; $r < $size; $r++) for ($c = 0; $c < $size; $c++) {
+            if ($fn[$r][$c]) continue;
+            $inv = match ($mask) {
+                0 => ($r + $c) % 2 === 0,
+                1 => $r % 2 === 0,
+                2 => $c % 3 === 0,
+                3 => ($r + $c) % 3 === 0,
+                4 => (intdiv($r, 2) + intdiv($c, 3)) % 2 === 0,
+                5 => (($r * $c) % 2) + (($r * $c) % 3) === 0,
+                6 => ((($r * $c) % 2) + (($r * $c) % 3)) % 2 === 0,
+                7 => ((($r + $c) % 2) + (($r * $c) % 3)) % 2 === 0,
+            };
+            if ($inv) $mm[$r][$c] ^= 1;
+        }
+        qr_place_format($mm, $fn, $size, $mask);
+        $pen = qr_penalty($mm, $size);
+        if ($pen < $bestPen) { $bestPen = $pen; $best = $mm; $bestMask = $mask; }
+    }
+    return [$best, $size];
+}
+
+/** يضع معلومات الصيغة (تصحيح L=01 + القناع) بترميز BCH */
+function qr_place_format(array &$m, array $fn, int $size, int $mask): void {
+    $data = (0b01 << 3) | $mask;               // L=01
+    $bch = $data << 10;
+    $g = 0b10100110111;
+    for ($i = 4; $i >= 0; $i--) if (($bch >> ($i + 10)) & 1) $bch ^= $g << $i;
+    $fi = (($data << 10) | $bch) ^ 0b101010000010010;   // قيمة الصيغة (15 بت، البت 14 الأعلى)
+    // وضع مطابق لـ ISO/segno: نسختان حول أنماط الكاشف
+    for ($i = 0; $i < 8; $i++) {
+        $vbit = ($fi >> $i) & 1;
+        $hbit = ($fi >> (14 - $i)) & 1;
+        $off  = ($i >= 6) ? 1 : 0;                 // تخطّي عمود/صف التوقيت (6)
+        $m[$i + $off][8]        = $vbit;           // عمودي — أعلى اليسار
+        $m[8][$i + $off]        = $hbit;           // أفقي — أعلى اليسار
+        $m[8][$size - 1 - $i]   = $vbit;           // أفقي — أعلى اليمين
+        $m[$size - 1 - $i][8]   = $hbit;           // عمودي — أسفل اليسار
+    }
+    $m[$size - 8][8] = 1;                          // الوحدة الداكنة
+}
+
+/** جزاء القناع (قواعد QR الأربع) */
+function qr_penalty(array $m, int $size): int {
+    $p = 0;
+    // القاعدة 1: تتابعات ≥5
+    for ($r = 0; $r < $size; $r++) {
+        $run = 1;
+        for ($c = 1; $c < $size; $c++) {
+            if ($m[$r][$c] === $m[$r][$c-1]) { $run++; if ($run === 5) $p += 3; elseif ($run > 5) $p++; }
+            else $run = 1;
+        }
+    }
+    for ($c = 0; $c < $size; $c++) {
+        $run = 1;
+        for ($r = 1; $r < $size; $r++) {
+            if ($m[$r][$c] === $m[$r-1][$c]) { $run++; if ($run === 5) $p += 3; elseif ($run > 5) $p++; }
+            else $run = 1;
+        }
+    }
+    // القاعدة 2: كتل 2×2
+    for ($r = 0; $r < $size - 1; $r++) for ($c = 0; $c < $size - 1; $c++)
+        if ($m[$r][$c] === $m[$r][$c+1] && $m[$r][$c] === $m[$r+1][$c] && $m[$r][$c] === $m[$r+1][$c+1]) $p += 3;
+    // القاعدة 3: نمط 1011101 + 0000
+    $pat1 = [1,0,1,1,1,0,1,0,0,0,0]; $pat2 = [0,0,0,0,1,0,1,1,1,0,1];
+    for ($r = 0; $r < $size; $r++) for ($c = 0; $c <= $size - 11; $c++) {
+        $seg = array_slice($m[$r], $c, 11);
+        if ($seg === $pat1 || $seg === $pat2) $p += 40;
+    }
+    for ($c = 0; $c < $size; $c++) for ($r = 0; $r <= $size - 11; $r++) {
+        $seg = []; for ($k = 0; $k < 11; $k++) $seg[] = $m[$r+$k][$c];
+        if ($seg === $pat1 || $seg === $pat2) $p += 40;
+    }
+    // القاعدة 4: توازن الأبيض/الأسود
+    $dark = 0; foreach ($m as $row) $dark += array_sum($row);
+    $ratio = $dark / ($size * $size) * 100;
+    $p += (int)(abs($ratio - 50) / 5) * 10;
+    return $p;
+}
+
+/** يرسم QR كـ SVG (وحدات سوداء على أبيض) بحدّ هادئ (quiet zone) */
+function qr_svg(string $data, int $scale = 6, int $quiet = 4): string {
+    [$m, $size] = qr_matrix($data);
+    $dim = ($size + $quiet * 2) * $scale;
+    $svg = "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"$dim\" height=\"$dim\" viewBox=\"0 0 $dim $dim\" shape-rendering=\"crispEdges\">";
+    $svg .= "<rect width=\"$dim\" height=\"$dim\" fill=\"#fff\"/>";
+    $svg .= '<path fill="#000" d="';
+    for ($r = 0; $r < $size; $r++) for ($c = 0; $c < $size; $c++) if ($m[$r][$c]) {
+        $x = ($c + $quiet) * $scale; $y = ($r + $quiet) * $scale;
+        $svg .= "M$x $y h$scale v$scale h-$scale z";
+    }
+    $svg .= '"/></svg>';
+    return $svg;
+}

--- a/xcamp-gym-sql/deploy.sh
+++ b/xcamp-gym-sql/deploy.sh
@@ -24,6 +24,7 @@ FILES=(
   "09_nutrition_v2.sql"
   "10_member_portal.sql"
   "11_finance_pos.sql"
+  "12_checkin_qr.sql"
   "07_test_queries.sql"
 )
 

--- a/xcamp-gym-sql/run_all.sql
+++ b/xcamp-gym-sql/run_all.sql
@@ -14,6 +14,7 @@ SOURCE sql/08_workout_v2.sql;
 SOURCE sql/09_nutrition_v2.sql;
 SOURCE sql/10_member_portal.sql;
 SOURCE sql/11_finance_pos.sql;
+SOURCE sql/12_checkin_qr.sql;
 SOURCE sql/07_test_queries.sql;
 
 -- Restore the session state saved in 00_init.sql (valid here because run_all

--- a/xcamp-gym-sql/sql/12_checkin_qr.sql
+++ b/xcamp-gym-sql/sql/12_checkin_qr.sql
@@ -1,0 +1,22 @@
+-- =============================================================================
+-- xcamp-gym-sql : 12_checkin_qr.sql  (ترقية إضافية — لا تمسّ المخطط الأصلي)
+-- -----------------------------------------------------------------------------
+-- الحضور بالـ QR: رمز فريد لكل عضو يُمسح عند الدخول → حضور تلقائي (daily_attendance).
+--   member_qr   رمز الدخول (token) لكل عضو
+-- تسجيل الحضور يُكتب في daily_attendance الموجود بالمخطط فتعمل أتمتة المتابعة.
+--
+-- الملف قابل لإعادة التشغيل: CREATE IF NOT EXISTS.
+-- =============================================================================
+
+USE xcamp_gym;
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS member_qr (
+    member_id  BIGINT UNSIGNED NOT NULL,
+    token      VARCHAR(32)     NOT NULL,
+    created_at TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (member_id),
+    UNIQUE KEY uq_member_qr_token (token),
+    CONSTRAINT fk_member_qr_member FOREIGN KEY (member_id)
+        REFERENCES members (member_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;


### PR DESCRIPTION
## Summary

A QR check-in system that connects **attendance ↔ member portal ↔ automation**. No external libraries or internet — the QR is generated in **pure PHP**.

## `qr.php` — from-scratch QR encoder

Byte mode, error-correction level L, versions 1–4, Reed–Solomon EC, best-mask selection, rendered as crisp SVG. **Validated bit-for-bit against the `segno` reference across 648 cases** (every data length 1–78 × all 8 masks), so the output is a valid, universally scannable QR. (Getting there surfaced and fixed several classic QR bugs: the timing-column direction flip, PHP `xor` precedence, format-info bit order, and the byte-mode zero-pad byte.)

## `sql/12_checkin_qr.sql` (additive)

`member_qr` table — a unique per-member token. Wired into `run_all.sql` and `deploy.sh`. **Check-ins write to the existing `daily_attendance` table**, firing the attendance automation (onboarding→active, at_risk→reactivated, flag resolution) — no new attendance store.

## Pages

- **`checkin.php`** — a front-desk / kiosk screen. A keyboard-wedge QR/barcode scanner (or a typed phone/id) resolves the member and records today's attendance once, then shows a **confirmation card** with membership status and **expiry / payment alerts**. The scan field stays focused for continuous scanning; today's check-ins are listed. Adds a **الحضور (QR)** nav link.
- **`portal.php`** — each member sees **their own QR code** (&#34;رمز دخولك&#34;) to show at the desk. `db.php`&#39;s `member_qr_token()` lazily mints/stores a 16-char token.

## Verification (live MariaDB 10.11 + PHP 8.4)

- Token generated (`XCG-…`, 16 chars); scanning it **records `daily_attendance` (attended=1)** and greets the member.
- The portal renders the QR and it **matches segno bit-for-bit for that exact token** (mask 2) — i.e. a valid scannable code that decodes back to the token.
- Fresh **`run_all.sql`** clean (migrations 11 + 12); `php -l` clean; screenshots (kiosk + member QR) captured.

## Note

Includes a migration — after merge run once with `./update.sh --deploy` to create `member_qr`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK

---
_Generated by [Claude Code](https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK)_