### PR TITLE
PT sessions: shift-driven booking for staff and the member portal

### DIFF
--- a/xcamp-gym-sql/dashboard/db.php
+++ b/xcamp-gym-sql/dashboard/db.php
@@ -90,6 +90,49 @@ function require_member(): array {
     return $m;
 }
 
+// ---- جلسات التدريب الشخصي (PT): سعر افتراضي + حساب المواعيد المتاحة من الورديات ----
+if (!defined('PT_PRICE'))    define('PT_PRICE', 150);   // سعر الجلسة الافتراضي (ج.م)
+if (!defined('PT_SLOT_MIN')) define('PT_SLOT_MIN', 60); // مدّة الموعد بالدقائق
+
+/** يعرض مدى وقتي (بداية–نهاية) معزولًا LTR ليقرأ صحيحًا داخل صفحة RTL. */
+function trange($start, $end, bool $boldStart = false): string {
+    $a = substr((string)$start, 0, 5); $b = substr((string)$end, 0, 5);
+    $left = $boldStart ? "<strong>$a</strong>" : $a;
+    return '<span dir="ltr" style="unicode-bidi:isolate;display:inline-block">' . $left . '–' . $b . '</span>';
+}
+
+/** يحوّل التاريخ إلى ترميز يوم الأسبوع المستخدم في coach_shifts (0=السبت..6=الجمعة). */
+function pt_weekday_for(string $date): int {
+    return ((int)date('w', strtotime($date)) + 1) % 7;  // PHP: 0=الأحد..6=السبت
+}
+
+/**
+ * يبني مواعيد جلسات كابتن في تاريخ معيّن من ورديات ذلك اليوم، ويعلّم المحجوز.
+ * @return array<int,array{start:string,end:string,free:bool}>
+ */
+function pt_slots_for(PDO $pdo, int $coachId, string $date, int $slotMin = PT_SLOT_MIN): array {
+    $wd = pt_weekday_for($date);
+    $sh = $pdo->prepare("SELECT start_time, end_time FROM coach_shifts WHERE coach_id = ? AND weekday = ? ORDER BY start_time");
+    $sh->execute([$coachId, $wd]);
+    $shifts = $sh->fetchAll();
+    $bk = $pdo->prepare("SELECT start_time, end_time FROM pt_sessions
+                         WHERE coach_id = ? AND session_date = ? AND status IN ('booked','completed')");
+    $bk->execute([$coachId, $date]);
+    $busy = $bk->fetchAll();
+    $slots = [];
+    foreach ($shifts as $s) {
+        $t = strtotime($s['start_time']); $end = strtotime($s['end_time']);
+        while ($t + $slotMin * 60 <= $end) {
+            $st = date('H:i:s', $t); $en = date('H:i:s', $t + $slotMin * 60);
+            $free = true;
+            foreach ($busy as $b) if ($st < $b['end_time'] && $en > $b['start_time']) { $free = false; break; }
+            $slots[] = ['start' => $st, 'end' => $en, 'free' => $free];
+            $t += $slotMin * 60;
+        }
+    }
+    return $slots;
+}
+
 // ---- حماية CSRF ----
 function csrf_token(): string {
     if (empty($_SESSION['csrf'])) $_SESSION['csrf'] = bin2hex(random_bytes(32));
@@ -124,6 +167,7 @@ function page_head(string $title, string $active = ''): void {
   <nav>
     <?php if (is_manager()): ?><a href="index.php" class="<?= $active==='dash' ? 'active' : '' ?>">لوحة الإدارة</a><?php endif; ?>
     <a href="captains.php" class="<?= $active==='captains' ? 'active' : '' ?>">واجهة الكباتن</a>
+    <a href="pt.php" class="<?= $active==='pt' ? 'active' : '' ?>">جلسات PT</a>
     <a href="checkin.php" class="<?= $active==='checkin' ? 'active' : '' ?>">الحضور (QR)</a>
     <a href="crm.php" class="<?= $active==='crm' ? 'active' : '' ?>">CRM</a>
     <a href="retention.php" class="<?= $active==='retention' ? 'active' : '' ?>">الاحتفاظ</a>

--- a/xcamp-gym-sql/dashboard/portal.php
+++ b/xcamp-gym-sql/dashboard/portal.php
@@ -66,12 +66,32 @@ if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
                            VALUES (?,?,?,?,?,?,?)")
                 ->execute([$meId, $_POST['record_date'] ?: date('Y-m-d'), $num('weight'), $num('body_fat'),
                            $num('muscle_mass'), $num('waist'), trim($_POST['performance_note'] ?? '') ?: null]);
+        } elseif ($act === 'member_book_pt') {
+            if (!$myCoach) throw new RuntimeException('لا كابتن مُسنَد لك بعد — تواصل مع الاستقبال.');
+            $date = $_POST['session_date'] ?? '';
+            $start = $_POST['start_time'] ?? '';
+            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) || $date < date('Y-m-d'))
+                throw new RuntimeException('اختر تاريخًا اليوم أو لاحقًا.');
+            // تأكيد أن الموعد متاح فعلًا ضمن ورديات الكابتن وغير محجوز
+            $ok = false; $endT = null; $want = strlen($start) === 5 ? $start . ':00' : $start;
+            foreach (pt_slots_for($pdo, (int)$myCoach, $date) as $s)
+                if ($s['start'] === $want && $s['free']) { $ok = true; $endT = $s['end']; break; }
+            if (!$ok) throw new RuntimeException('الموعد لم يعد متاحًا — اختر موعدًا آخر.');
+            $pdo->prepare("INSERT INTO pt_sessions (member_id, coach_id, session_date, start_time, end_time, status, booked_by, price)
+                           VALUES (?,?,?,?,?, 'booked', 'member', ?)")
+                ->execute([$meId, (int)$myCoach, $date, $want, $endT, PT_PRICE]);
+        } elseif ($act === 'member_cancel_pt') {
+            // العضو يلغي جلسته المحجوزة المستقبلية فقط
+            $pdo->prepare("UPDATE pt_sessions SET status='cancelled'
+                           WHERE pt_id = ? AND member_id = ? AND status='booked' AND session_date >= CURDATE()")
+                ->execute([(int)$_POST['pt_id'], $meId]);
         } elseif ($act === 'member_request_renewal') {
             $pdo->prepare("INSERT INTO tasks (member_id, coach_id, task_type, priority, status, due_at, notes)
                            VALUES (?,?,'renewal','high','open', DATE_ADD(NOW(), INTERVAL 3 DAY), 'طلب تجديد من العضو عبر البوابة')")
                 ->execute([$meId, $myCoach]);
         }
-        header('Location: portal.php?ok=1');
+        $ret = isset($_POST['ret_date']) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $_POST['ret_date']) ? '&ptd=' . urlencode($_POST['ret_date']) : '';
+        header('Location: portal.php?ok=1' . $ret);
         exit;
     } catch (Throwable $e) {
         $error = 'تعذّر الحفظ: ' . $e->getMessage();
@@ -144,6 +164,23 @@ $prog->execute([$meId]); $prog = $prog->fetchAll();
 $mile = $pdo->prepare("SELECT * FROM milestones WHERE member_id = ? ORDER BY milestone_date DESC, milestone_id DESC LIMIT 8");
 $mile->execute([$meId]); $mile = $mile->fetchAll();
 
+// جلسات PT: اسم الكابتن + مواعيد اليوم المختار + جلسات العضو
+$ptCoachName = null;
+if ($myCoach) { $cn = $pdo->prepare("SELECT full_name FROM coaches WHERE coach_id = ?"); $cn->execute([(int)$myCoach]); $ptCoachName = $cn->fetchColumn() ?: null; }
+$ptSelDate = $_GET['ptd'] ?? '';
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', (string)$ptSelDate)) $ptSelDate = '';
+$ptSlots = []; $ptSlotErr = null;
+if ($myCoach && $ptSelDate) {
+    if ($ptSelDate < date('Y-m-d')) $ptSlotErr = 'اختر تاريخًا اليوم أو لاحقًا.';
+    else { $ptSlots = pt_slots_for($pdo, (int)$myCoach, $ptSelDate);
+           if (!$ptSlots) $ptSlotErr = 'لا مواعيد متاحة لكابتنك في هذا اليوم — جرّب يومًا آخر.'; }
+}
+$myPt = $pdo->prepare("SELECT pt.*, c.full_name cname FROM pt_sessions pt JOIN coaches c ON c.coach_id=pt.coach_id
+                       WHERE pt.member_id = ? ORDER BY (pt.status='booked' AND pt.session_date>=CURDATE()) DESC, pt.session_date DESC, pt.start_time DESC LIMIT 20");
+$myPt->execute([$meId]); $myPt = $myPt->fetchAll();
+$ptStMeta = ['booked'=>['محجوز','#2563eb'],'completed'=>['مكتملة','#16a34a'],'cancelled'=>['ملغاة','#6b7280'],'no_show'=>['تخلّف','#dc2626']];
+$hm = fn($t) => substr((string)$t, 0, 5);
+
 $stColor = ['planned'=>'#2563eb','completed'=>'#16a34a','partial'=>'#f59e0b','missed'=>'#dc2626'];
 $payColor = ['paid'=>'#16a34a','partial'=>'#f59e0b','unpaid'=>'#dc2626','failed'=>'#dc2626','refunded'=>'#6b7280'];
 ?>
@@ -154,6 +191,7 @@ $payColor = ['paid'=>'#16a34a','partial'=>'#f59e0b','unpaid'=>'#dc2626','failed'
   <button type="button" data-tabtarget="prog">🏋️ برنامجي</button>
   <button type="button" data-tabtarget="nutr">🥗 تغذيتي</button>
   <button type="button" data-tabtarget="track">📈 تقدّمي</button>
+  <button type="button" data-tabtarget="pt">🏋️‍♂️ جلسات PT</button>
   <button type="button" data-tabtarget="sub">🎫 اشتراكي</button>
 </nav>
 
@@ -286,6 +324,65 @@ $payColor = ['paid'=>'#16a34a','partial'=>'#f59e0b','unpaid'=>'#dc2626','failed'
     <div style="grid-column:1/-1"><label>ملاحظة</label><input name="performance_note"></div>
     <div><button type="submit">حفظ القياس</button></div>
   </form>
+</section>
+
+<!-- ===== جلسات PT ===== -->
+<section data-tab="pt">
+  <h2>🏋️‍♂️ جلسات التدريب الشخصي</h2>
+  <?php if (!$myCoach): ?>
+    <div class="empty">لا كابتن مُسنَد لك بعد — تواصل مع الاستقبال لحجز جلسة شخصية.</div>
+  <?php else: ?>
+    <p class="muted" style="font-size:13px;margin-top:0">كابتنك: <strong><?=h($ptCoachName)?></strong> · سعر الجلسة <?=money(PT_PRICE)?></p>
+    <h3>📆 احجز موعدًا</h3>
+    <form method="get" data-no-ajax class="frm" style="align-items:end">
+      <div><label>اختر اليوم</label><input type="date" name="ptd" value="<?=h($ptSelDate ?: date('Y-m-d'))?>" min="<?=date('Y-m-d')?>" required></div>
+      <div><button type="submit">🔎 اعرض المواعيد</button></div>
+    </form>
+    <?php if ($ptSelDate): ?>
+      <?php if ($ptSlotErr): ?>
+        <div class="err" style="margin-top:10px"><?=h($ptSlotErr)?></div>
+      <?php else: ?>
+        <div style="display:flex;flex-wrap:wrap;gap:8px;margin:10px 0">
+          <?php foreach ($ptSlots as $s): ?>
+            <?php if ($s['free']): ?>
+              <form method="post" style="margin:0"><?=csrf_field()?>
+                <input type="hidden" name="action" value="member_book_pt">
+                <input type="hidden" name="session_date" value="<?=h($ptSelDate)?>">
+                <input type="hidden" name="start_time" value="<?=h($s['start'])?>">
+                <input type="hidden" name="ret_date" value="<?=h($ptSelDate)?>">
+                <button type="submit" onclick="return confirm('حجز موعد <?=$hm($s['start'])?> يوم <?=h($ptSelDate)?>؟')" style="background:#eff6ff;color:#1e40af;border:1px solid #bfdbfe;border-radius:8px;padding:9px 14px;font-weight:700;cursor:pointer"><?=trange($s['start'],$s['end'])?></button>
+              </form>
+            <?php else: ?>
+              <span style="background:#f1f5f9;color:#94a3b8;border:1px solid #e2e8f0;border-radius:8px;padding:9px 14px;text-decoration:line-through"><?=trange($s['start'],$s['end'])?></span>
+            <?php endif; ?>
+          <?php endforeach; ?>
+        </div>
+      <?php endif; ?>
+    <?php endif; ?>
+    <h3>🗓️ جلساتي</h3>
+    <?php if (!$myPt): ?><div class="empty">لا جلسات بعد — احجز أول جلسة بالأعلى.</div><?php else: ?>
+    <table>
+      <tr><th>التاريخ</th><th>الوقت</th><th>الكابتن</th><th>الحالة</th><th></th></tr>
+      <?php foreach ($myPt as $r): [$lbl,$col] = $ptStMeta[$r['status']];
+        $future = $r['status']==='booked' && $r['session_date'] >= date('Y-m-d'); ?>
+        <tr>
+          <td><?=h($r['session_date'])?></td>
+          <td><?=trange($r['start_time'],$r['end_time'])?></td>
+          <td class="muted"><?=h($r['cname'])?></td>
+          <td><span class="badge" style="background:<?=$col?>"><?=$lbl?></span></td>
+          <td>
+            <?php if ($future): ?>
+              <form method="post" style="margin:0" onsubmit="return confirm('إلغاء هذه الجلسة؟')"><?=csrf_field()?>
+                <input type="hidden" name="action" value="member_cancel_pt"><input type="hidden" name="pt_id" value="<?=(int)$r['pt_id']?>">
+                <button type="submit" style="background:none;border:1px solid #fecaca;color:#dc2626;border-radius:6px;padding:3px 10px;font-size:11px;cursor:pointer">إلغاء</button>
+              </form>
+            <?php endif; ?>
+          </td>
+        </tr>
+      <?php endforeach; ?>
+    </table>
+    <?php endif; ?>
+  <?php endif; ?>
 </section>
 
 <!-- ===== اشتراكي ===== -->

--- a/xcamp-gym-sql/dashboard/pt.php
+++ b/xcamp-gym-sql/dashboard/pt.php
@@ -1,0 +1,220 @@
+<?php
+// =============================================================================
+// Xcamp Gym — جلسات التدريب الشخصي (PT): إدارة مواعيد الكباتن مع الأعضاء.
+// الكابتن يرى/يحجز لأعضائه فقط؛ المدير يتصفّح كل الكباتن. المواعيد تُشتقّ من
+// ورديات الكابتن (coach_shifts)، مع دورة حالة وإيراد من الجلسات المكتملة.
+// =============================================================================
+require __DIR__ . '/db.php';
+$me = require_login();
+
+$error = null;
+try { $pdo = db(); } catch (Throwable $e) { $error = $e->getMessage(); }
+
+$isCoach = ($me['role'] === 'coach');
+$myCoachId = $isCoach ? (int)($me['coach_id'] ?? 0) : 0;
+
+/** يتأكّد أن الكابتن يتعامل مع عضو من أعضائه فقط (المدير: الكل). */
+function pt_member_coach(PDO $pdo, int $memberId): ?int {
+    $q = $pdo->prepare("SELECT coach_id FROM members WHERE member_id = ?");
+    $q->execute([$memberId]);
+    $c = $q->fetchColumn();
+    return $c !== false && $c !== null ? (int)$c : null;
+}
+
+if ($pdo && !$error && $_SERVER['REQUEST_METHOD'] === 'POST') {
+    try {
+        csrf_check();
+        $act = $_POST['action'] ?? '';
+        if ($act === 'book') {
+            $memberId = (int)($_POST['member_id'] ?? 0);
+            $date = $_POST['session_date'] ?? '';
+            $start = $_POST['start_time'] ?? '';
+            if (!$memberId || !$date || !$start) throw new RuntimeException('أكمل بيانات الحجز.');
+            if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date) || $date < date('Y-m-d'))
+                throw new RuntimeException('اختر تاريخًا اليوم أو لاحقًا.');
+            $coachId = pt_member_coach($pdo, $memberId);
+            if (!$coachId) throw new RuntimeException('لا كابتن مُسنَد لهذا العضو.');
+            if ($isCoach && $coachId !== $myCoachId) throw new RuntimeException('غير مسموح — العضو ليس ضمن أعضائك.');
+            // تحقّق أن الموعد ضمن مواعيد متاحة فعلًا (وردية + غير محجوز)
+            $ok = false; $endT = null;
+            foreach (pt_slots_for($pdo, $coachId, $date) as $s)
+                if ($s['start'] === (strlen($start) === 5 ? $start . ':00' : $start) && $s['free']) { $ok = true; $endT = $s['end']; break; }
+            if (!$ok) throw new RuntimeException('الموعد غير متاح — جرّب موعدًا آخر.');
+            $price = $_POST['price'] !== '' ? max(0, (float)$_POST['price']) : PT_PRICE;
+            $pdo->prepare("INSERT INTO pt_sessions (member_id, coach_id, session_date, start_time, end_time, status, booked_by, price, notes)
+                           VALUES (?,?,?,?,?, 'booked', 'staff', ?, ?)")
+                ->execute([$memberId, $coachId, $date, (strlen($start) === 5 ? $start . ':00' : $start), $endT, $price,
+                           trim($_POST['notes'] ?? '') ?: null]);
+        } elseif ($act === 'set_status') {
+            $pid = (int)$_POST['pt_id'];
+            $ns  = in_array($_POST['status'] ?? '', ['completed','cancelled','no_show','booked'], true) ? $_POST['status'] : null;
+            if (!$ns) throw new RuntimeException('حالة غير صحيحة.');
+            // قيد الكابتن على جلساته
+            $own = "UPDATE pt_sessions SET status = ? WHERE pt_id = ?" . ($isCoach ? " AND coach_id = " . $myCoachId : "");
+            $pdo->prepare($own)->execute([$ns, $pid]);
+        }
+        header('Location: pt.php?ok=1' . (isset($_POST['ret_date']) ? '&d=' . urlencode($_POST['ret_date']) . '&m=' . (int)($_POST['member_id'] ?? 0) : ''));
+        exit;
+    } catch (Throwable $e) {
+        $error = 'تعذّر الحفظ: ' . $e->getMessage();
+    }
+}
+
+page_head('جلسات PT', 'pt');
+if ($error && !$pdo) { db_error_box($error); page_foot(); exit; }
+if ($error) echo '<div class="err">' . h($error) . '</div>';
+if (isset($_GET['ok'])) echo '<div class="flash">تم الحفظ بنجاح ✓</div>';
+
+$scope = $isCoach ? " AND pt.coach_id = " . $myCoachId : "";
+
+// ---- KPIs ----
+$kpiWeek = (int)$pdo->query("SELECT COUNT(*) FROM pt_sessions pt WHERE pt.status='booked'
+    AND pt.session_date BETWEEN CURDATE() AND DATE_ADD(CURDATE(), INTERVAL 7 DAY)$scope")->fetchColumn();
+$kpiDone = (int)$pdo->query("SELECT COUNT(*) FROM pt_sessions pt WHERE pt.status='completed'
+    AND YEAR(pt.session_date)=YEAR(CURDATE()) AND MONTH(pt.session_date)=MONTH(CURDATE())$scope")->fetchColumn();
+$kpiRev  = (float)$pdo->query("SELECT COALESCE(SUM(pt.price),0) FROM pt_sessions pt WHERE pt.status='completed'
+    AND YEAR(pt.session_date)=YEAR(CURDATE()) AND MONTH(pt.session_date)=MONTH(CURDATE())$scope")->fetchColumn();
+$kpiNoShow = (int)$pdo->query("SELECT COUNT(*) FROM pt_sessions pt WHERE pt.status='no_show'
+    AND pt.session_date >= DATE_SUB(CURDATE(), INTERVAL 30 DAY)$scope")->fetchColumn();
+
+// ---- القادمة ----
+$upcoming = $pdo->query("SELECT pt.*, m.full_name mname, c.full_name cname FROM pt_sessions pt
+    JOIN members m ON m.member_id=pt.member_id JOIN coaches c ON c.coach_id=pt.coach_id
+    WHERE pt.status='booked' AND pt.session_date >= CURDATE()$scope
+    ORDER BY pt.session_date, pt.start_time")->fetchAll();
+
+// ---- السجل (آخر ما جرى) ----
+$history = $pdo->query("SELECT pt.*, m.full_name mname, c.full_name cname FROM pt_sessions pt
+    JOIN members m ON m.member_id=pt.member_id JOIN coaches c ON c.coach_id=pt.coach_id
+    WHERE (pt.status <> 'booked' OR pt.session_date < CURDATE())$scope
+    ORDER BY pt.session_date DESC, pt.start_time DESC LIMIT 40")->fetchAll();
+
+// ---- الأعضاء المتاحون للحجز ----
+$memWhere = $isCoach ? "WHERE coach_id = " . $myCoachId . " AND coach_id IS NOT NULL" : "WHERE coach_id IS NOT NULL AND status <> 'expired'";
+$members = $pdo->query("SELECT member_id, full_name FROM members $memWhere ORDER BY full_name")->fetchAll();
+
+// ---- حالة نموذج الحجز (اختيار عضو + تاريخ ⇒ عرض المواعيد) ----
+$selMember = (int)($_GET['m'] ?? 0);
+$selDate   = $_GET['d'] ?? '';
+if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', (string)$selDate)) $selDate = '';
+$slots = []; $slotCoach = null; $slotErr = null;
+if ($selMember && $selDate) {
+    $slotCoach = pt_member_coach($pdo, $selMember);
+    if ($isCoach && $slotCoach !== $myCoachId) $slotErr = 'العضو ليس ضمن أعضائك.';
+    elseif (!$slotCoach) $slotErr = 'لا كابتن مُسنَد لهذا العضو.';
+    elseif ($selDate < date('Y-m-d')) $slotErr = 'اختر تاريخًا اليوم أو لاحقًا.';
+    else {
+        $slots = pt_slots_for($pdo, $slotCoach, $selDate);
+        if (!$slots) $slotErr = 'لا ورديات لهذا الكابتن في هذا اليوم — أضِف وردية من «شؤون الكباتن».';
+    }
+}
+
+$stMeta = ['booked'=>['محجوز','#2563eb'],'completed'=>['مكتملة','#16a34a'],'cancelled'=>['ملغاة','#6b7280'],'no_show'=>['تخلّف','#dc2626']];
+$WD = [0=>'السبت',1=>'الأحد',2=>'الاثنين',3=>'الثلاثاء',4=>'الأربعاء',5=>'الخميس',6=>'الجمعة'];
+$hm = fn($t) => substr((string)$t, 0, 5);
+?>
+<div style="margin-bottom:6px"><h2 style="margin:0">🏋️‍♂️ جلسات التدريب الشخصي (PT)</h2></div>
+<div class="kpis">
+  <div class="card" style="--c:#2563eb"><div class="n"><?=$kpiWeek?></div><div class="l">محجوزة هذا الأسبوع</div></div>
+  <div class="card" style="--c:#16a34a"><div class="n"><?=$kpiDone?></div><div class="l">مكتملة هذا الشهر</div></div>
+  <div class="card" style="--c:#0891b2"><div class="n" style="font-size:22px"><?=money($kpiRev)?></div><div class="l">إيراد الجلسات (الشهر)</div></div>
+  <div class="card" style="--c:#dc2626"><div class="n"><?=$kpiNoShow?></div><div class="l">تخلّف (٣٠ يومًا)</div></div>
+</div>
+
+<nav class="tabbar" aria-label="أقسام الجلسات">
+  <button type="button" data-tabtarget="up">📅 القادمة</button>
+  <button type="button" data-tabtarget="new">➕ حجز جلسة</button>
+  <button type="button" data-tabtarget="hist">🗂️ السجل</button>
+</nav>
+
+<!-- ===== القادمة ===== -->
+<section data-tab="up">
+  <h2>📅 المواعيد القادمة (<?=count($upcoming)?>)</h2>
+  <?php if (!$upcoming): ?><div class="empty">لا مواعيد قادمة — احجز من تبويب «حجز جلسة».</div><?php else: ?>
+  <table>
+    <tr><th>التاريخ</th><th>اليوم</th><th>الوقت</th><th>العضو</th><?php if(!$isCoach):?><th>الكابتن</th><?php endif;?><th>السعر</th><th>الإجراء</th></tr>
+    <?php foreach ($upcoming as $r): $wd = pt_weekday_for($r['session_date']); ?>
+      <tr>
+        <td><?=h($r['session_date'])?></td>
+        <td class="muted"><?=$WD[$wd]?></td>
+        <td><?=trange($r['start_time'],$r['end_time'],true)?></td>
+        <td><?=h($r['mname'])?></td>
+        <?php if(!$isCoach):?><td class="muted"><?=h($r['cname'])?></td><?php endif;?>
+        <td><?=money((float)$r['price'])?></td>
+        <td style="white-space:nowrap">
+          <?php foreach (['completed'=>['✓ تمّت','#16a34a'],'no_show'=>['✗ تخلّف','#dc2626'],'cancelled'=>['إلغاء','#6b7280']] as $s=>$b): ?>
+            <form method="post" style="display:inline;margin:0 1px"><?=csrf_field()?>
+              <input type="hidden" name="action" value="set_status"><input type="hidden" name="pt_id" value="<?=(int)$r['pt_id']?>"><input type="hidden" name="status" value="<?=$s?>">
+              <button type="submit" style="background:<?=$b[1]?>;color:#fff;border:0;padding:4px 8px;border-radius:6px;font-size:11px;cursor:pointer"><?=$b[0]?></button>
+            </form>
+          <?php endforeach; ?>
+        </td>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+  <?php endif; ?>
+</section>
+
+<!-- ===== حجز جلسة ===== -->
+<section data-tab="new">
+  <h2>➕ حجز جلسة</h2>
+  <?php if (!$members): ?><div class="empty">لا أعضاء متاحون للحجز.</div><?php else: ?>
+  <form method="get" data-no-ajax class="frm" style="align-items:end">
+    <div><label>العضو</label><select name="m" required>
+      <option value="">— اختر —</option>
+      <?php foreach ($members as $mm): ?><option value="<?=(int)$mm['member_id']?>" <?=$selMember===(int)$mm['member_id']?'selected':''?>><?=h($mm['full_name'])?></option><?php endforeach; ?>
+    </select></div>
+    <div><label>التاريخ</label><input type="date" name="d" value="<?=h($selDate ?: date('Y-m-d'))?>" min="<?=date('Y-m-d')?>" required></div>
+    <div><button type="submit">🔎 اعرض المواعيد المتاحة</button></div>
+  </form>
+
+  <?php if ($selMember && $selDate): ?>
+    <?php if ($slotErr): ?>
+      <div class="err" style="margin-top:12px"><?=h($slotErr)?></div>
+    <?php else: ?>
+      <h3><?=$WD[pt_weekday_for($selDate)]?> <?=h($selDate)?> — المواعيد المتاحة</h3>
+      <div style="display:flex;flex-wrap:wrap;gap:8px;margin-bottom:8px">
+        <?php foreach ($slots as $s): $free = $s['free']; ?>
+          <?php if ($free): ?>
+            <form method="post" style="margin:0"><?=csrf_field()?>
+              <input type="hidden" name="action" value="book">
+              <input type="hidden" name="member_id" value="<?=$selMember?>">
+              <input type="hidden" name="session_date" value="<?=h($selDate)?>">
+              <input type="hidden" name="start_time" value="<?=h($s['start'])?>">
+              <input type="hidden" name="price" value="<?=PT_PRICE?>">
+              <input type="hidden" name="ret_date" value="<?=h($selDate)?>">
+              <button type="submit" title="احجز <?=$hm($s['start'])?>" style="background:#eff6ff;color:#1e40af;border:1px solid #bfdbfe;border-radius:8px;padding:8px 12px;font-weight:700;cursor:pointer"><?=trange($s['start'],$s['end'])?></button>
+            </form>
+          <?php else: ?>
+            <span style="background:#f1f5f9;color:#94a3b8;border:1px solid #e2e8f0;border-radius:8px;padding:8px 12px;text-decoration:line-through"><?=trange($s['start'],$s['end'])?></span>
+          <?php endif; ?>
+        <?php endforeach; ?>
+      </div>
+      <p class="muted" style="font-size:12px">اضغط موعدًا لحجزه (سعر الجلسة الافتراضي <?=money(PT_PRICE)?>). المشطوب محجوز مسبقًا.</p>
+    <?php endif; ?>
+  <?php else: ?>
+    <p class="muted" style="font-size:13px;margin-top:10px">اختر عضوًا وتاريخًا لعرض المواعيد المتاحة من ورديات كابتنه.</p>
+  <?php endif; ?>
+  <?php endif; ?>
+</section>
+
+<!-- ===== السجل ===== -->
+<section data-tab="hist">
+  <h2>🗂️ سجلّ الجلسات</h2>
+  <?php if (!$history): ?><div class="empty">لا سجلّ بعد.</div><?php else: ?>
+  <table>
+    <tr><th>التاريخ</th><th>الوقت</th><th>العضو</th><?php if(!$isCoach):?><th>الكابتن</th><?php endif;?><th>السعر</th><th>الحالة</th></tr>
+    <?php foreach ($history as $r): [$lbl,$col] = $stMeta[$r['status']]; ?>
+      <tr>
+        <td><?=h($r['session_date'])?></td>
+        <td><?=trange($r['start_time'],$r['end_time'])?></td>
+        <td><?=h($r['mname'])?></td>
+        <?php if(!$isCoach):?><td class="muted"><?=h($r['cname'])?></td><?php endif;?>
+        <td><?= $r['status']==='completed' ? '<strong style="color:#16a34a">'.money((float)$r['price']).'</strong>' : '<span class="muted">'.money((float)$r['price']).'</span>' ?></td>
+        <td><span class="badge" style="background:<?=$col?>"><?=$lbl?></span></td>
+      </tr>
+    <?php endforeach; ?>
+  </table>
+  <?php endif; ?>
+</section>
+<?php page_foot();

--- a/xcamp-gym-sql/deploy.sh
+++ b/xcamp-gym-sql/deploy.sh
@@ -26,6 +26,7 @@ FILES=(
   "11_finance_pos.sql"
   "12_checkin_qr.sql"
   "13_coach_hr.sql"
+  "14_pt_sessions.sql"
   "07_test_queries.sql"
 )
 

--- a/xcamp-gym-sql/run_all.sql
+++ b/xcamp-gym-sql/run_all.sql
@@ -16,6 +16,7 @@ SOURCE sql/10_member_portal.sql;
 SOURCE sql/11_finance_pos.sql;
 SOURCE sql/12_checkin_qr.sql;
 SOURCE sql/13_coach_hr.sql;
+SOURCE sql/14_pt_sessions.sql;
 SOURCE sql/07_test_queries.sql;
 
 -- Restore the session state saved in 00_init.sql (valid here because run_all

--- a/xcamp-gym-sql/sql/14_pt_sessions.sql
+++ b/xcamp-gym-sql/sql/14_pt_sessions.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- xcamp-gym-sql : 14_pt_sessions.sql  (ترقية إضافية — لا تمسّ المخطط الأصلي)
+-- -----------------------------------------------------------------------------
+-- حجز جلسات التدريب الشخصي (PT): العضو/الاستقبال يحجز موعدًا مع الكابتن ضمن
+-- ورديات الكابتن (من coach_shifts)، مع دورة حالة (محجوز/مكتمل/ملغى/تخلّف) وسعر.
+--   pt_sessions   موعد جلسة شخصية لعضو مع كابتن في تاريخ/وقت.
+-- كما نبذر ورديات افتراضية للكباتن بلا ورديات ليعمل الحجز مباشرةً بعد النشر.
+--
+-- الملف قابل لإعادة التشغيل: CREATE IF NOT EXISTS + بذر محروس بـ NOT EXISTS.
+-- =============================================================================
+
+USE xcamp_gym;
+SET NAMES utf8mb4;
+
+CREATE TABLE IF NOT EXISTS pt_sessions (
+    pt_id        BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+    member_id    BIGINT UNSIGNED NOT NULL,
+    coach_id     BIGINT UNSIGNED NOT NULL,
+    session_date DATE            NOT NULL,
+    start_time   TIME            NOT NULL,
+    end_time     TIME            NOT NULL,
+    status       ENUM('booked','completed','cancelled','no_show') NOT NULL DEFAULT 'booked',
+    booked_by    ENUM('member','staff') NOT NULL DEFAULT 'member',
+    price        DECIMAL(10,2)   NOT NULL DEFAULT 0.00,
+    notes        VARCHAR(300)    NULL,
+    created_at   TIMESTAMP       NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (pt_id),
+    KEY idx_pt_coach_date (coach_id, session_date),
+    KEY idx_pt_member (member_id),
+    CONSTRAINT fk_pt_member FOREIGN KEY (member_id) REFERENCES members (member_id) ON DELETE CASCADE,
+    CONSTRAINT fk_pt_coach  FOREIGN KEY (coach_id)  REFERENCES coaches (coach_id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+-- ورديات افتراضية للكباتن الذين لا ورديات لهم: الأحد/الثلاثاء/الخميس 16:00–21:00
+-- (weekday: 0=السبت .. 6=الجمعة ⇒ 1=الأحد، 3=الثلاثاء، 5=الخميس)
+INSERT INTO coach_shifts (coach_id, weekday, start_time, end_time)
+SELECT c.coach_id, d.wd, '16:00:00', '21:00:00'
+FROM coaches c
+CROSS JOIN (SELECT 1 AS wd UNION ALL SELECT 3 UNION ALL SELECT 5) d
+WHERE c.active = 1
+  AND NOT EXISTS (SELECT 1 FROM coach_shifts s WHERE s.coach_id = c.coach_id);


### PR DESCRIPTION
## جلسات التدريب الشخصي (PT)

نظام حجز جلسات شخصية **تُشتقّ مواعيده من ورديات كل كابتن** (نفس `coach_shifts` من وحدة شؤون الكباتن) — تكامل مباشر يجعل الورديات مصدر التوفّر الحقيقي.

### ما الجديد

**`sql/14_pt_sessions.sql`** — ترقية إضافية موصولة في `run_all.sql` و`deploy.sh`:
- `pt_sessions` — عضو/كابتن/تاريخ/وقت، حالة (`booked`/`completed`/`cancelled`/`no_show`)، جهة الحجز، وسعر.
- تبذر ورديات افتراضية (الأحد/الثلاثاء/الخميس 16:00–21:00) لأي كابتن بلا ورديات، ليعمل الحجز فور النشر.

**`dashboard/db.php`** — دوال مشتركة:
- `pt_slots_for()` تبني مواعيد بطول ساعة من ورديات الكابتن في تاريخ معيّن وتعلّم المحجوز.
- `pt_weekday_for()` · `trange()` لعرض المدى الوقتي معزولًا LTR ليقرأ صحيحًا داخل RTL · ثوابت `PT_PRICE`/`PT_SLOT_MIN` · رابط تنقّل «جلسات PT».

**`dashboard/pt.php`** (طاقم؛ الكابتن مقيَّد بأعضائه، المدير يرى الكل): مؤشرات (محجوز هذا الأسبوع، مكتمل + إيراد الشهر، تخلّف)، قائمة قادمة بأزرار تمّت/تخلّف/إلغاء، تدفّق حجز يعرض المواعيد المتاحة لعضو+تاريخ، وسجلّ.

**`dashboard/portal.php`** — تبويب «جلسات PT» يحجز فيه العضو موعدًا مع كابتنه ويلغي حجوزاته القادمة.

### الأمان
التحقّق من جهة الخادم يعيد التأكّد أن الموعد ضمن وردية الكابتن وما زال متاحًا قبل الإدراج؛ الكابتن لا يمسّ جلسات كابتن آخر؛ العضو يتصرّف في جلساته فقط.

### الاختبار (فعلي على MariaDB)
- حجز من الطاقم، استبعاد المواعيد المحجوزة، تعليم مكتملة (يُحتسب إيرادًا).
- حجز العضو من البوابة ثم الإلغاء (يحرّر الموعد).
- قيد نطاق الكابتن ومحاولات العبث عبر الكباتن — مرفوضة.
- لقطات لكل التبويبات (الطاقم + البوابة) بعد إصلاح اتجاه عرض الوقت (RTL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012tYKjc71fJ28dRgfaCEYLK)_